### PR TITLE
[Chore] Sentry 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'com.h2database:h2'
+
+	// Sentry
+	implementation 'io.sentry:sentry-spring-boot-starter:6.27.0'
+	implementation 'io.sentry:sentry-logback:6.27.0'
 }
 
 jacoco {

--- a/src/main/resources/application-datasource.yaml
+++ b/src/main/resources/application-datasource.yaml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: "datasource"
+
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PW}
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,17 +1,17 @@
 spring:
-    config:
-        activate:
-            on-profile: local
-    datasource:
-        url: jdbc:mysql://localhost:3306/gigedi
-        username: ${LOCAL_DB_USER}
-        password: ${LOCAL_DB_PW}
-        driver-class-name: com.mysql.cj.jdbc.Driver
-    jpa:
-        hibernate:
-            ddl-auto: update
-        properties:
-            hibernate:
-                format_sql: true
-                dialect: org.hibernate.dialect.MySQLDialect
+  config:
+    activate:
+      on-profile: "local"
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+logging:
+  level:
+    org.springframework.orm.jpa: DEBUG
+    org.springframework.transaction: DEBUG
 

--- a/src/main/resources/application-log.yaml
+++ b/src/main/resources/application-log.yaml
@@ -1,0 +1,14 @@
+spring:
+  config:
+    activate:
+      on-profile: "log"
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  enable: true
+  environment: ${SENTRY_ENV}
+  traces-sample-rate: 1.0
+  logging:
+    exception-resolver-order: -2147483647
+    minimum-event-level: error
+    minimum-breadcrumb-level: info

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,5 @@
 spring:
   profiles:
-    active: local
+    group:
+      test: "test"
+      local: "local, datasource"

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,22 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="SENTRY"/>
+        </root>
+
+        <logger name="org.springframework.web" level="ERROR">
+            <appender-ref ref="SENTRY" />
+        </logger>
+    </springProfile>
+
+    <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnErrorEvaluator" />
+            <OnMismatch>DENY</OnMismatch>
+            <OnMatch>ACCEPT</OnMatch>
+        </filter>
+    </appender>
+
+</configuration>


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #2 

## 💡 작업내용
### 1. 프로파일 설정을 통한 환경분리
- 프로파일을 여러 환경에서 다르게 사용하기 위하여 분리하였습니다. 
  ``` 
  application.yaml             // 그룹 설정
  application-local.yaml       // 로컬 환경 설정
  application-datasource.yaml  // DB연결 설정
  application-log.yaml         // Sentry를 포함한 로그 설정
  ```
### 2. sentry 설정을 진행
- logback 설정까지 진행 했지만 추후 보충이 필요합니다. 

## 📸 스크린샷(선택)
로컬에서 임시 api 생성 후 예외 테스트 시 장면
![image](https://github.com/user-attachments/assets/810219c7-e7bb-400e-9112-614c4ad71aed)


## 📝 기타
- 설정이 생각보다 복잡하여 연동만 진행했습니다. 이후 개발이 조금 진행된 이후 추가적인 설정을 하면 좋을 것 같습니다. 

- 배포를 통해 `dev`와 `prod` 환경 설정 시에 프로파일 설정이 필요할 것 같습니다. 

- Sentry 등의 환경변수 설정을 위해 **노션에 올린 .env파일 내용을 확인해주세요.**