### PR TITLE
[Feat] 토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
+++ b/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
@@ -1,11 +1,9 @@
 package gigedi.dev.domain.auth.api;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import gigedi.dev.domain.auth.application.AuthService;
+import gigedi.dev.domain.auth.dto.request.TokenRefreshRequest;
 import gigedi.dev.domain.auth.dto.response.TokenPairResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,5 +20,11 @@ public class AuthController {
     @GetMapping("/code/google")
     public TokenPairResponse googleSocialLogin(@RequestParam String code) {
         return authService.googleSocialLogin(code);
+    }
+
+    @Operation(summary = "토큰 재발급", description = "엑세스 토큰 및 리프테시 토큰을 모두 재발급합니다.")
+    @PostMapping("/refresh")
+    public TokenPairResponse refreshToken(@RequestBody TokenRefreshRequest request) {
+        return authService.refreshToken(request);
     }
 }

--- a/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
@@ -9,8 +9,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import gigedi.dev.domain.auth.dao.RefreshTokenRepository;
 import gigedi.dev.domain.auth.domain.RefreshToken;
+import gigedi.dev.domain.auth.dto.AccessTokenDto;
+import gigedi.dev.domain.auth.dto.RefreshTokenDto;
+import gigedi.dev.domain.member.domain.Member;
 import gigedi.dev.domain.member.domain.MemberRole;
-import gigedi.dev.domain.member.dto.AccessTokenDto;
+import gigedi.dev.global.error.exception.CustomException;
+import gigedi.dev.global.error.exception.ErrorCode;
 import gigedi.dev.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 
@@ -50,5 +54,25 @@ public class JwtTokenService {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public RefreshTokenDto validateRefreshToken(String refreshToken) {
+        return jwtUtil.parseRefreshToken(refreshToken);
+    }
+
+    public AccessTokenDto refreshAccessToken(Member member) {
+        return jwtUtil.generateAccessTokenDto(member.getId(), member.getRole());
+    }
+
+    public RefreshTokenDto refreshRefreshToken(RefreshTokenDto oldRefreshTokenDto) {
+        RefreshToken refreshToken =
+                refreshTokenRepository
+                        .findById(oldRefreshTokenDto.getMemberId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MISSING_JWT_TOKEN));
+        RefreshTokenDto refreshTokenDto =
+                jwtUtil.generateRefreshTokenDto(refreshToken.getMemberId());
+        refreshToken.updateRefreshToken(refreshTokenDto.getToken());
+        refreshTokenRepository.save(refreshToken);
+        return refreshTokenDto;
     }
 }

--- a/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import gigedi.dev.domain.auth.dao.RefreshTokenRepository;
 import gigedi.dev.domain.auth.domain.RefreshToken;
 import gigedi.dev.domain.member.domain.MemberRole;
+import gigedi.dev.domain.member.dto.AccessTokenDto;
 import gigedi.dev.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 
@@ -41,5 +42,13 @@ public class JwtTokenService {
                 new UsernamePasswordAuthenticationToken(
                         userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/gigedi/dev/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/gigedi/dev/domain/auth/domain/RefreshToken.java
@@ -23,4 +23,8 @@ public class RefreshToken {
     public static RefreshToken of(Long memberId, String token) {
         return RefreshToken.builder().memberId(memberId).token(token).build();
     }
+
+    public void updateRefreshToken(String newToken) {
+        this.token = newToken;
+    }
 }

--- a/src/main/java/gigedi/dev/domain/auth/dto/AccessTokenDto.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/AccessTokenDto.java
@@ -1,4 +1,4 @@
-package gigedi.dev.domain.member.dto;
+package gigedi.dev.domain.auth.dto;
 
 import gigedi.dev.domain.member.domain.MemberRole;
 import lombok.AllArgsConstructor;

--- a/src/main/java/gigedi/dev/domain/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/RefreshTokenDto.java
@@ -1,0 +1,11 @@
+package gigedi.dev.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshTokenDto {
+    private Long memberId;
+    private String token;
+}

--- a/src/main/java/gigedi/dev/domain/auth/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,12 @@
+package gigedi.dev.domain.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TokenRefreshRequest {
+    private String refreshToken;
+}

--- a/src/main/java/gigedi/dev/domain/member/domain/Member.java
+++ b/src/main/java/gigedi/dev/domain/member/domain/Member.java
@@ -26,13 +26,13 @@ public class Member extends BaseTimeEntity {
     private LocalDateTime lastLoginAt;
 
     @Enumerated(EnumType.STRING)
-    private MemberRole memberRole;
+    private MemberRole role;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Member(OauthInfo oauthInfo, LocalDateTime lastLoginAt, MemberRole role) {
         this.oauthInfo = oauthInfo;
         this.lastLoginAt = lastLoginAt;
-        this.memberRole = role;
+        this.role = role;
     }
 
     public static Member createMember(OauthInfo oauthInfo) {

--- a/src/main/java/gigedi/dev/domain/member/dto/AccessTokenDto.java
+++ b/src/main/java/gigedi/dev/domain/member/dto/AccessTokenDto.java
@@ -1,0 +1,13 @@
+package gigedi.dev.domain.member.dto;
+
+import gigedi.dev.domain.member.domain.MemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AccessTokenDto {
+    private Long memberId;
+    private MemberRole role;
+    private String token;
+}

--- a/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
+++ b/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
@@ -12,6 +12,8 @@ public final class SecurityConstants {
     public static final String GOOGLE_JWK_SET_URL = "https://www.googleapis.com/oauth2/v3/certs";
 
     public static final String TOKEN_ROLE_NAME = "role";
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String NONE = "";
 
     private SecurityConstants() {
         throw new AssertionError();

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     // Security
     AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보를 찾을 수 없습니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    MISSING_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 정보가 존재하지 않습니다."),
     MEMBER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 회원입니다."),
     MEMBER_ALREADY_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     MEMBER_INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "올바르지 않는 닉네임입니다."),

--- a/src/main/java/gigedi/dev/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/gigedi/dev/global/security/JwtAuthenticationFilter.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import gigedi.dev.domain.auth.application.JwtTokenService;
-import gigedi.dev.domain.member.dto.AccessTokenDto;
+import gigedi.dev.domain.auth.dto.AccessTokenDto;
 import lombok.RequiredArgsConstructor;
 
 @Component

--- a/src/main/java/gigedi/dev/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/gigedi/dev/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package gigedi.dev.global.security;
+
+import static gigedi.dev.global.common.constants.SecurityConstants.*;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import gigedi.dev.domain.auth.application.JwtTokenService;
+import gigedi.dev.domain.member.dto.AccessTokenDto;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
+
+        if (accessTokenHeaderValue != null) {
+            AccessTokenDto accessTokenDto =
+                    jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+            if (accessTokenDto != null) {
+                jwtTokenService.setAuthenticationToken(
+                        accessTokenDto.getMemberId(), accessTokenDto.getRole());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith(TOKEN_PREFIX)) {
+            return header.replace(TOKEN_PREFIX, NONE);
+        }
+        return null;
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
 
-    <springProfile name="local">
+    <springProfile name="dev">
         <root level="INFO">
             <appender-ref ref="SENTRY"/>
         </root>


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #15 

## 💡 작업내용
### jwt 파싱 필터 추가
- jwt 필터를 추가하여 클라이언트가 서버에 요청 시 `SecurityContextHolder`에 사용자 정보가 기록되도록 설정하였습니다. 

### 토큰 재발급 로직 추가
- 요청 본문에 가지고 있던 리프레시 토큰을 넣어 요청시 토큰이 재발급되는 로직을 추가하였습니다.

### logback 활성화 환경 변경
- 해당 pr에 맞는 주제는 아니지만 간단한 작업이어서 변경했습니다. 

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/ab2fc785-629f-4c59-9069-9d80ffe0838f)

## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
