### PR TITLE
[Feat] 로그아웃 및 회원탈퇴 구현

### DIFF
--- a/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
+++ b/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
@@ -1,5 +1,6 @@
 package gigedi.dev.domain.auth.api;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import gigedi.dev.domain.auth.application.AuthService;
@@ -26,5 +27,12 @@ public class AuthController {
     @PostMapping("/refresh")
     public TokenPairResponse refreshToken(@RequestBody TokenRefreshRequest request) {
         return authService.refreshToken(request);
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행하는 API")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> memberLogout() {
+        authService.memberLogout();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
+++ b/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
@@ -35,4 +35,11 @@ public class AuthController {
         authService.memberLogout();
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "회원탈퇴", description = "회원탈퇴를 진행하는 API")
+    @GetMapping("/withdrawal")
+    public ResponseEntity<Void> memberWithdrawal() {
+        authService.memberWithdrawal();
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
@@ -70,8 +70,7 @@ public class AuthService {
     private Member getOrCreateMember(OidcUser user) {
         OauthInfo oauthInfo = createOauthInfo(user);
         return memberRepository
-                .findByOauthInfoGoogleId(oauthInfo.getGoogleId())
-                .filter(member -> member.getDeletedAt() == null)
+                .findByOauthInfoGoogleIdAndDeletedAtIsNull(oauthInfo.getGoogleId())
                 .orElseGet(() -> memberRepository.save(Member.createMember(oauthInfo)));
     }
 

--- a/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
@@ -14,6 +14,7 @@ import gigedi.dev.domain.member.domain.Member;
 import gigedi.dev.domain.member.domain.OauthInfo;
 import gigedi.dev.global.error.exception.CustomException;
 import gigedi.dev.global.error.exception.ErrorCode;
+import gigedi.dev.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -24,6 +25,7 @@ public class AuthService {
     private final IdTokenVerifier idTokenVerifier;
     private final MemberRepository memberRepository;
     private final JwtTokenService jwtTokenService;
+    private final MemberUtil memberUtil;
 
     public TokenPairResponse googleSocialLogin(String code) {
         OidcUser user = getOidcUserFromGoogle(code);
@@ -43,6 +45,11 @@ public class AuthService {
         AccessTokenDto accessTokenDto =
                 jwtTokenService.refreshAccessToken(getMember(newRefreshTokenDto));
         return new TokenPairResponse(accessTokenDto.getToken(), newRefreshTokenDto.getToken());
+    }
+
+    public void memberLogout() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        jwtTokenService.deleteRefreshToken(currentMember);
     }
 
     private Member getMember(RefreshTokenDto refreshTokenDto) {

--- a/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
@@ -54,6 +54,13 @@ public class AuthService {
         jwtTokenService.deleteRefreshToken(currentMember);
     }
 
+    public void memberWithdrawal() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        jwtTokenService.deleteRefreshToken(currentMember);
+        googleService.googleWithdrawal(currentMember.getId());
+        currentMember.memberWithdrawal();
+    }
+
     private Member getMember(RefreshTokenDto refreshTokenDto) {
         return memberRepository
                 .findById(refreshTokenDto.getMemberId())

--- a/src/main/java/gigedi/dev/domain/auth/application/GoogleService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/GoogleService.java
@@ -13,6 +13,7 @@ import org.springframework.web.client.RestClient;
 import gigedi.dev.domain.auth.dao.GoogleRepository;
 import gigedi.dev.domain.auth.domain.Google;
 import gigedi.dev.domain.auth.dto.response.GoogleLoginResponse;
+import gigedi.dev.domain.auth.dto.response.GoogleReissueResponse;
 import gigedi.dev.global.error.exception.CustomException;
 import gigedi.dev.global.error.exception.ErrorCode;
 import gigedi.dev.infra.config.oauth.GoogleProperties;
@@ -58,5 +59,61 @@ public class GoogleService {
 
     public void saveGoogleRefreshToken(Long memberId, String token) {
         googleRepository.save(Google.of(memberId, token));
+    }
+
+    public void googleWithdrawal(Long memberId) {
+        Google google =
+                googleRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.GOOGLE_AUTH_NOT_FOUND));
+        GoogleReissueResponse response = getAccessTokenWithRefreshToken(google.getToken());
+        googleWithdrawalWithAccessToken(response.getAccessToken());
+        googleRepository.delete(google);
+    }
+
+    private GoogleReissueResponse getAccessTokenWithRefreshToken(String refreshToken) {
+        try {
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add(GRANT_TYPE_KEY, REISSUE_GRANT_TYPE_VALUE);
+            formData.add(REFRESH_TOKEN, refreshToken);
+            formData.add(CLIENT_ID_KEY, googleProperties.getId());
+            formData.add(CLIENT_ID_SECRET, googleProperties.getSecret());
+
+            return restClient
+                    .post()
+                    .uri(GOOGLE_TOKEN_REISSUE_URL)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(
+                            status -> !status.is2xxSuccessful(),
+                            (request, response) -> {
+                                log.error("Access Token 요청 실패: {}", response.getStatusCode());
+                                throw new CustomException(ErrorCode.GOOGLE_TOKEN_REISSUE_FAILED);
+                            })
+                    .body(GoogleReissueResponse.class);
+        } catch (Exception e) {
+            log.error("Access Token 요청 중 예외 발생 : {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.GOOGLE_TOKEN_REISSUE_FAILED);
+        }
+    }
+
+    private void googleWithdrawalWithAccessToken(String accessToken) {
+        try {
+            restClient
+                    .post()
+                    .uri(GOOGLE_WITHDRAWAL_URL + accessToken)
+                    .retrieve()
+                    .onStatus(
+                            status -> !status.is2xxSuccessful(),
+                            (request, response) -> {
+                                log.error("Google 계정 연결 해제 실패: {}", response.getStatusCode());
+                                throw new CustomException(ErrorCode.GOOGLE_WITHDRAWAL_FAILED);
+                            })
+                    .body(Void.class);
+        } catch (Exception e) {
+            log.error("Google 계정 연결 해제 중 예외 발생 : {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.GOOGLE_WITHDRAWAL_FAILED);
+        }
     }
 }

--- a/src/main/java/gigedi/dev/domain/auth/application/GoogleService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/GoogleService.java
@@ -10,6 +10,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
+import gigedi.dev.domain.auth.dao.GoogleRepository;
+import gigedi.dev.domain.auth.domain.Google;
 import gigedi.dev.domain.auth.dto.response.GoogleLoginResponse;
 import gigedi.dev.global.error.exception.CustomException;
 import gigedi.dev.global.error.exception.ErrorCode;
@@ -23,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class GoogleService {
     private final GoogleProperties googleProperties;
+    private final GoogleRepository googleRepository;
     private final RestClient restClient;
 
     public GoogleLoginResponse getIdTokenByGoogleLogin(String code) {
@@ -51,5 +54,9 @@ public class GoogleService {
             log.error("Google 로그인 중 예외 발생 : {}", e.getMessage(), e);
             throw new CustomException(ErrorCode.GOOGLE_LOGIN_FAILED);
         }
+    }
+
+    public void saveGoogleRefreshToken(Long memberId, String token) {
+        googleRepository.save(Google.of(memberId, token));
     }
 }

--- a/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
@@ -1,5 +1,7 @@
 package gigedi.dev.domain.auth.application;
 
+import static gigedi.dev.global.common.constants.SecurityConstants.NONE;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -40,7 +42,7 @@ public class JwtTokenService {
         UserDetails userDetails =
                 User.withUsername(memberId.toString())
                         .authorities(role.toString())
-                        .password("")
+                        .password(NONE)
                         .build();
         UsernamePasswordAuthenticationToken token =
                 new UsernamePasswordAuthenticationToken(

--- a/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
@@ -1,7 +1,5 @@
 package gigedi.dev.domain.auth.application;
 
-import static gigedi.dev.global.common.constants.SecurityConstants.NONE;
-
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -42,7 +40,7 @@ public class JwtTokenService {
         UserDetails userDetails =
                 User.withUsername(memberId.toString())
                         .authorities(role.toString())
-                        .password(NONE)
+                        .password("")
                         .build();
         UsernamePasswordAuthenticationToken token =
                 new UsernamePasswordAuthenticationToken(

--- a/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
@@ -75,4 +75,8 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
         return refreshTokenDto;
     }
+
+    public void deleteRefreshToken(Member member) {
+        refreshTokenRepository.findById(member.getId()).ifPresent(refreshTokenRepository::delete);
+    }
 }

--- a/src/main/java/gigedi/dev/domain/auth/dao/GoogleRepository.java
+++ b/src/main/java/gigedi/dev/domain/auth/dao/GoogleRepository.java
@@ -1,0 +1,7 @@
+package gigedi.dev.domain.auth.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import gigedi.dev.domain.auth.domain.Google;
+
+public interface GoogleRepository extends JpaRepository<Google, Long> {}

--- a/src/main/java/gigedi/dev/domain/auth/domain/Google.java
+++ b/src/main/java/gigedi/dev/domain/auth/domain/Google.java
@@ -1,6 +1,7 @@
 package gigedi.dev.domain.auth.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,21 +11,17 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken {
+public class Google {
     @Id private Long memberId;
     private String token;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private RefreshToken(Long memberId, String token) {
+    private Google(Long memberId, String token) {
         this.memberId = memberId;
         this.token = token;
     }
 
-    public static RefreshToken of(Long memberId, String token) {
-        return RefreshToken.builder().memberId(memberId).token(token).build();
-    }
-
-    public void updateRefreshToken(String newToken) {
-        this.token = newToken;
+    public static Google of(Long memberId, String token) {
+        return Google.builder().memberId(memberId).token(token).build();
     }
 }

--- a/src/main/java/gigedi/dev/domain/auth/dto/response/GoogleReissueResponse.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/response/GoogleReissueResponse.java
@@ -10,4 +10,7 @@ import lombok.Getter;
 public class GoogleReissueResponse {
     @JsonProperty("access_token")
     private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
 }

--- a/src/main/java/gigedi/dev/domain/auth/dto/response/GoogleReissueResponse.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/response/GoogleReissueResponse.java
@@ -1,0 +1,13 @@
+package gigedi.dev.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GoogleReissueResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+}

--- a/src/main/java/gigedi/dev/domain/auth/dto/response/TokenPairResponse.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/response/TokenPairResponse.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class TokenPairResponse {
-    private final String refreshToken;
     private final String accessToken;
+    private final String refreshToken;
 }

--- a/src/main/java/gigedi/dev/domain/member/dao/MemberRepository.java
+++ b/src/main/java/gigedi/dev/domain/member/dao/MemberRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import gigedi.dev.domain.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByOauthInfoGoogleId(String googleId);
+    Optional<Member> findByOauthInfoGoogleIdAndDeletedAtIsNull(String googleId);
 }

--- a/src/main/java/gigedi/dev/domain/member/domain/Member.java
+++ b/src/main/java/gigedi/dev/domain/member/domain/Member.java
@@ -45,4 +45,8 @@ public class Member extends BaseTimeEntity {
                 .role(MemberRole.USER)
                 .build();
     }
+
+    public void memberWithdrawal() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
+++ b/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
@@ -6,10 +6,15 @@ public final class SecurityConstants {
     public static final String CLIENT_ID_SECRET = "client_secret";
     public static final String REDIRECT_URI_KEY = "redirect_uri";
     public static final String GRANT_TYPE_KEY = "grant_type";
+    public static final String REISSUE_GRANT_TYPE_VALUE = "refresh_token";
+    public static final String REFRESH_TOKEN = "refresh_token";
 
     public static final String GET_ID_TOKEN_URL = "https://oauth2.googleapis.com/token";
     public static final String GOOGLE_ISSUER = "https://accounts.google.com";
     public static final String GOOGLE_JWK_SET_URL = "https://www.googleapis.com/oauth2/v3/certs";
+    public static final String GOOGLE_TOKEN_REISSUE_URL = "https://oauth2.googleapis.com/token";
+    public static final String GOOGLE_WITHDRAWAL_URL =
+            "https://accounts.google.com/o/oauth2/revoke?token=";
 
     public static final String TOKEN_ROLE_NAME = "role";
     public static final String TOKEN_PREFIX = "Bearer ";

--- a/src/main/java/gigedi/dev/global/config/SwaggerConfig.java
+++ b/src/main/java/gigedi/dev/global/config/SwaggerConfig.java
@@ -6,8 +6,10 @@ import org.springframework.context.annotation.Configuration;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @OpenAPIDefinition(
         info = @Info(title = "GIGEDI", description = "큐시즘 30기 밋업 프로젝트 기개디 API 문서", version = "v1"),
@@ -21,19 +23,17 @@ public class SwaggerConfig {
     public OpenAPI openAPI() {
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
-        // 추후 설정
-        /* Components components = new Components()
-                        .addSecuritySchemes("bearerAuth",
+        Components components =
+                new Components()
+                        .addSecuritySchemes(
+                                "bearerAuth",
                                 new SecurityScheme()
                                         .type(SecurityScheme.Type.HTTP)
                                         .scheme("bearer")
                                         .bearerFormat("JWT")
                                         .in(SecurityScheme.In.HEADER)
-                                        .name("Authorization")
-                        );
-        */
-        return new OpenAPI()
-                // .components(components)
-                .addSecurityItem(securityRequirement);
+                                        .name("Authorization"));
+
+        return new OpenAPI().components(components).addSecurityItem(securityRequirement);
     }
 }

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -33,7 +33,10 @@ public enum ErrorCode {
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
 
     // 추가
-    GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "구글 로그인 과정에서 오류가 발생했습니다.");
+    GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "구글 로그인 과정에서 오류가 발생했습니다."),
+    GOOGLE_AUTH_NOT_FOUND(HttpStatus.BAD_REQUEST, "구글 리프레시 토큰이 존재하지 않습니다."),
+    GOOGLE_TOKEN_REISSUE_FAILED(HttpStatus.BAD_REQUEST, "구글 토큰 재발급에 실패했습니다."),
+    GOOGLE_WITHDRAWAL_FAILED(HttpStatus.BAD_REQUEST, "구글 회원탈퇴에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #17 

## 💡 작업내용
### 로그아웃 구현
- 저장되어 있던 리프레시 토큰이 삭제되도록 구현하였습니다.

### 회원탈퇴 구현
- 탈퇴를 위해서는 구글 엑세스토큰이 필요하여 구글 리프레시 토큰을 따로 저장하고 이를 이용하여 회원탈퇴 요청시 엑세스 토큰을 발급받고 그를 이용하여 탈퇴되도록 구현하였습니다.

### 회원 저장 로직 변경
- 이전에는 `googleId`를 기준으로 조회한 다음 `deleteAt`이 `null`인지 필터링 하는 과정으로 진행했으나, 사용자가 여러번 가입 탈퇴를 반복한 경우 `googleId`가 같은 여러개의 레코드가 존재하여 에러가 발생했습니다.
- 때문에 `memberRepository`에서 조회시 특정 `googleId`이면서 `deleteAt`이 `null`인 `member`를 찾도록 이중조건의 JPA 메소드로 설정했습니다. 

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/a7db61ef-ce9e-4a73-9927-65a6b8d181d7)

## 📝 기타

