### PR TITLE
[CI/CD] .env 도커 실행 시 전달

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deploy to NCP
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "cicd/#21" ]
 
 env:
   DOCKERHUB_IMAGE_NAME: gigedi-server
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create .env file from GitHub Secrets
         run: |
-          echo "${{ secrets.ENV_FILE }}" > .env
+          echo "${{ secrets.ENV_FILE }}" | tr '\n' '\n' > .env
 
       - name: Copy docker-compose file and .env file to NCP
         uses: appleboy/scp-action@master

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -60,17 +60,15 @@ jobs:
 
       - name: Create .env file from GitHub Secrets
         run: |
-          printf "%s\n" "${{ secrets.ENV_FILE }}" > .env
+          echo "${{ secrets.ENV_FILE }}" | tr '\n' '\n' > .env
 
-      - name: Copy docker-compose file and .env file to NCP
+      - name: Copy docker-compose file to NCP
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.NCP_SERVER_IP }}
           username: ${{ secrets.NCP_SERVER_USER }}
           password: ${{ secrets.NCP_PASSWORD }}
-          source: |
-            docker-compose.yml
-            .env
+          source: docker-compose.yml
           target: "/root/"
           port: 22
           debug: true
@@ -84,5 +82,9 @@ jobs:
           port: 22
           script: |
             cd /root
-            docker-compose --env-file .env down
-            docker-compose --env-file .env up -d
+            docker-compose --env-file /dev/stdin down <<EOF
+            $(cat .env)
+            EOF
+            docker-compose --env-file /dev/stdin up -d <<EOF
+            $(cat .env)
+            EOF

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deploy to NCP
 
 on:
   push:
-    branches: [ "cicd/#21" ]
+    branches: [ "develop" ]
 
 env:
   DOCKERHUB_IMAGE_NAME: gigedi-server
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create .env file from GitHub Secrets
         run: |
-          echo "${{ secrets.ENV_FILE }}" | tr '\n' '\n' > .env
+          printf "%s\n" "${{ secrets.ENV_FILE }}" > .env
 
       - name: Copy docker-compose file and .env file to NCP
         uses: appleboy/scp-action@master

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deploy to NCP
 
 on:
   push:
-    branches: [ "cicd/#21" ]
+    branches: [ "develop" ]
 
 env:
   DOCKERHUB_IMAGE_NAME: gigedi-server

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deploy to NCP
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "cicd/#21" ]
 
 env:
   DOCKERHUB_IMAGE_NAME: gigedi-server

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -82,9 +82,6 @@ jobs:
           port: 22
           script: |
             cd /root
-            docker-compose --env-file /dev/stdin down <<EOF
-            $(cat .env)
-            EOF
-            docker-compose --env-file /dev/stdin up -d <<EOF
-            $(cat .env)
-            EOF
+            export $(cat /github/workspace/.env | xargs)
+            docker-compose down
+            docker-compose up -d


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #21 

## 💡 작업내용
-  github secrets의 env를 .env로 만들어 도커 컨테이너 실행 시 같이 실행되게 하고, 서버에는 넣지 않음
- 우분투에서 .env 삭제

## 📸 스크린샷(선택)

## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
