### PR TITLE
[Feat] 피그마 헤더 정보 인터셉터 및 유틸 추가

### DIFF
--- a/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
+++ b/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
@@ -1,0 +1,13 @@
+package gigedi.dev.domain.auth.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import gigedi.dev.domain.auth.domain.Figma;
+
+@Repository
+public interface FigmaRepository extends JpaRepository<Figma, Long> {
+    Optional<Figma> findByFigmaUserId(String figmaUserId);
+}

--- a/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepository.java
+++ b/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepository.java
@@ -1,0 +1,15 @@
+package gigedi.dev.domain.file.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import gigedi.dev.domain.auth.domain.Figma;
+import gigedi.dev.domain.file.domain.Authority;
+import gigedi.dev.domain.file.domain.File;
+
+@Repository
+public interface AuthorityRepository extends JpaRepository<Authority, Long> {
+    Optional<Authority> findByFigmaAndFile(Figma figma, File file);
+}

--- a/src/main/java/gigedi/dev/domain/file/dao/FileRepository.java
+++ b/src/main/java/gigedi/dev/domain/file/dao/FileRepository.java
@@ -1,0 +1,13 @@
+package gigedi.dev.domain.file.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import gigedi.dev.domain.file.domain.File;
+
+@Repository
+public interface FileRepository extends JpaRepository<File, Long> {
+    Optional<File> findByFileKey(String fileId);
+}

--- a/src/main/java/gigedi/dev/global/common/constants/FigmaConstants.java
+++ b/src/main/java/gigedi/dev/global/common/constants/FigmaConstants.java
@@ -1,0 +1,12 @@
+package gigedi.dev.global.common.constants;
+
+public final class FigmaConstants {
+    public static final String FIGMA_ID_HEADER = "Figma-Id";
+    public static final String FILE_ID_HEADER = "File-Id";
+    public static final String FIGMA_ID_ATTRIBUTE = "FIGMA_ID";
+    public static final String FILE_ID_ATTRIBUTE = "FILE_ID";
+
+    private FigmaConstants() {
+        throw new AssertionError();
+    }
+}

--- a/src/main/java/gigedi/dev/global/config/WebConfig.java
+++ b/src/main/java/gigedi/dev/global/config/WebConfig.java
@@ -2,7 +2,10 @@ package gigedi.dev.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import gigedi.dev.global.interceptor.FigmaInfoInterceptor;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -15,5 +18,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3000);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new FigmaInfoInterceptor());
     }
 }

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -36,7 +36,11 @@ public enum ErrorCode {
     GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "구글 로그인 과정에서 오류가 발생했습니다."),
     GOOGLE_AUTH_NOT_FOUND(HttpStatus.BAD_REQUEST, "구글 리프레시 토큰이 존재하지 않습니다."),
     GOOGLE_TOKEN_REISSUE_FAILED(HttpStatus.BAD_REQUEST, "구글 토큰 재발급에 실패했습니다."),
-    GOOGLE_WITHDRAWAL_FAILED(HttpStatus.BAD_REQUEST, "구글 회원탈퇴에 실패했습니다.");
+    GOOGLE_WITHDRAWAL_FAILED(HttpStatus.BAD_REQUEST, "구글 회원탈퇴에 실패했습니다."),
+
+    FIGMA_INFO_NOT_FOUND(HttpStatus.BAD_REQUEST, "피그마 정보가 포함되지 않았습니다."),
+    FIGMA_NOT_CONNECTED(HttpStatus.BAD_REQUEST, "피그마 계정이 연결되지 않았습니다."),
+    UNAUTHORIZED_FIGMA_ACCESS(HttpStatus.BAD_REQUEST, "해당 사용자와 피그마 계정이 연결되지 않았습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/gigedi/dev/global/interceptor/FigmaInfoInterceptor.java
+++ b/src/main/java/gigedi/dev/global/interceptor/FigmaInfoInterceptor.java
@@ -1,5 +1,7 @@
 package gigedi.dev.global.interceptor;
 
+import static gigedi.dev.global.common.constants.FigmaConstants.*;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -9,10 +11,6 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class FigmaInfoInterceptor implements HandlerInterceptor {
-    private static final String FIGMA_ID_HEADER = "Figma-Id";
-    private static final String FILE_ID_HEADER = "File-Id";
-    private static final String FIGMA_ID_ATTRIBUTE = "FIGMA_ID";
-    private static final String FILE_ID_ATTRIBUTE = "FILE_ID";
 
     @Override
     public boolean preHandle(

--- a/src/main/java/gigedi/dev/global/interceptor/FigmaInfoInterceptor.java
+++ b/src/main/java/gigedi/dev/global/interceptor/FigmaInfoInterceptor.java
@@ -1,0 +1,41 @@
+package gigedi.dev.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class FigmaInfoInterceptor implements HandlerInterceptor {
+    private static final String FIGMA_ID_HEADER = "Figma-Id";
+    private static final String FILE_ID_HEADER = "File-Id";
+    private static final String FIGMA_ID_ATTRIBUTE = "FIGMA_ID";
+    private static final String FILE_ID_ATTRIBUTE = "FILE_ID";
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        String figmaId = request.getHeader(FIGMA_ID_HEADER);
+        String fileId = request.getHeader(FILE_ID_HEADER);
+
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        attributes.setAttribute(FIGMA_ID_ATTRIBUTE, figmaId, RequestAttributes.SCOPE_REQUEST);
+        attributes.setAttribute(FILE_ID_ATTRIBUTE, fileId, RequestAttributes.SCOPE_REQUEST);
+
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(
+            HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        attributes.removeAttribute(FIGMA_ID_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+        attributes.removeAttribute(FILE_ID_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+    }
+}

--- a/src/main/java/gigedi/dev/global/util/FigmaUtil.java
+++ b/src/main/java/gigedi/dev/global/util/FigmaUtil.java
@@ -1,0 +1,86 @@
+package gigedi.dev.global.util;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import gigedi.dev.domain.auth.dao.FigmaRepository;
+import gigedi.dev.domain.auth.domain.Figma;
+import gigedi.dev.domain.file.dao.AuthorityRepository;
+import gigedi.dev.domain.file.dao.FileRepository;
+import gigedi.dev.domain.file.domain.Authority;
+import gigedi.dev.domain.file.domain.File;
+import gigedi.dev.domain.member.domain.Member;
+import gigedi.dev.global.error.exception.CustomException;
+import gigedi.dev.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FigmaUtil {
+    private final FigmaRepository figmaRepository;
+    private final FileRepository fileRepository;
+    private final AuthorityRepository authorityRepository;
+    private final MemberUtil memberUtil;
+
+    public Figma getCurrentFigma() {
+        String figmaId = getCurrentFigmaId();
+        if (figmaId == null || figmaId.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
+        }
+        return findAndValidateFigmaId(figmaId);
+    }
+
+    public File getCurrentFile() {
+        String fileId = getCurrentFileId();
+        if (fileId == null || fileId.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
+        }
+        Figma currentFigma = getCurrentFigma();
+
+        File currentFile =
+                fileRepository
+                        .findByFileKey(fileId)
+                        .orElseGet(() -> fileRepository.save(File.createFile(fileId)));
+
+        if (authorityRepository.findByFigmaAndFile(currentFigma, currentFile).isEmpty()) {
+            authorityRepository.save(Authority.createAuthority(currentFigma, currentFile));
+        }
+
+        return currentFile;
+    }
+
+    private String getCurrentFigmaId() {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes == null) {
+            throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
+        }
+        ServletRequestAttributes attributes = (ServletRequestAttributes) requestAttributes;
+        return (String) attributes.getAttribute("FIGMA_ID", RequestAttributes.SCOPE_REQUEST);
+    }
+
+    private String getCurrentFileId() {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes == null) {
+            throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
+        }
+        ServletRequestAttributes attributes = (ServletRequestAttributes) requestAttributes;
+        return (String) attributes.getAttribute("FILE_ID", RequestAttributes.SCOPE_REQUEST);
+    }
+
+    private Figma findAndValidateFigmaId(String figmaId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        Figma figma =
+                figmaRepository
+                        .findByFigmaUserId(figmaId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_NOT_CONNECTED));
+
+        if (!figma.getMember().equals(currentMember)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_FIGMA_ACCESS);
+        }
+
+        return figma;
+    }
+}

--- a/src/main/java/gigedi/dev/global/util/FigmaUtil.java
+++ b/src/main/java/gigedi/dev/global/util/FigmaUtil.java
@@ -1,5 +1,8 @@
 package gigedi.dev.global.util;
 
+import static gigedi.dev.global.common.constants.FigmaConstants.FIGMA_ID_ATTRIBUTE;
+import static gigedi.dev.global.common.constants.FigmaConstants.FILE_ID_ATTRIBUTE;
+
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -57,7 +60,8 @@ public class FigmaUtil {
             throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
         }
         ServletRequestAttributes attributes = (ServletRequestAttributes) requestAttributes;
-        return (String) attributes.getAttribute("FIGMA_ID", RequestAttributes.SCOPE_REQUEST);
+        return (String)
+                attributes.getAttribute(FIGMA_ID_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
     }
 
     private String getCurrentFileId() {
@@ -66,7 +70,7 @@ public class FigmaUtil {
             throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
         }
         ServletRequestAttributes attributes = (ServletRequestAttributes) requestAttributes;
-        return (String) attributes.getAttribute("FILE_ID", RequestAttributes.SCOPE_REQUEST);
+        return (String) attributes.getAttribute(FILE_ID_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
     }
 
     private Figma findAndValidateFigmaId(String figmaId) {

--- a/src/main/java/gigedi/dev/global/util/FigmaUtil.java
+++ b/src/main/java/gigedi/dev/global/util/FigmaUtil.java
@@ -28,18 +28,14 @@ public class FigmaUtil {
     private final MemberUtil memberUtil;
 
     public Figma getCurrentFigma() {
-        String figmaId = getCurrentFigmaId();
-        if (figmaId == null || figmaId.trim().isEmpty()) {
-            throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
-        }
+        String figmaId = getCurrentAttribute(FIGMA_ID_ATTRIBUTE);
+        validateId(figmaId);
         return findAndValidateFigmaId(figmaId);
     }
 
     public File getCurrentFile() {
-        String fileId = getCurrentFileId();
-        if (fileId == null || fileId.trim().isEmpty()) {
-            throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
-        }
+        String fileId = getCurrentAttribute(FILE_ID_ATTRIBUTE);
+        validateId(fileId);
         Figma currentFigma = getCurrentFigma();
 
         File currentFile =
@@ -54,23 +50,19 @@ public class FigmaUtil {
         return currentFile;
     }
 
-    private String getCurrentFigmaId() {
-        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes == null) {
+    private void validateId(String id) {
+        if (id == null || id.trim().isEmpty()) {
             throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
         }
-        ServletRequestAttributes attributes = (ServletRequestAttributes) requestAttributes;
-        return (String)
-                attributes.getAttribute(FIGMA_ID_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
     }
 
-    private String getCurrentFileId() {
+    private String getCurrentAttribute(String attributeName) {
         RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
         if (requestAttributes == null) {
             throw new CustomException(ErrorCode.FIGMA_INFO_NOT_FOUND);
         }
         ServletRequestAttributes attributes = (ServletRequestAttributes) requestAttributes;
-        return (String) attributes.getAttribute(FILE_ID_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+        return (String) attributes.getAttribute(attributeName, RequestAttributes.SCOPE_REQUEST);
     }
 
     private Figma findAndValidateFigmaId(String figmaId) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #29 

## 💡 작업내용
### 헤더 정보 필터링 인터셉터 추가
- 헤더에서 받은 정보를 `RequestContextHolder`에 저장하는 인터셉터를 구현하였습니다.

### 헤더 정보 사용 유틸 추가
- `RequestContextHolder`에서 `figmaId`와 `fileId`를 찾아 FIgma 객체와 File 객체를 찾아오는 유틸 함수를 추가했습니다.
  - 피그마 id로 피그마 객체 검색(없다면 예외 발생) -> 있다면 해당 피그마 객체가 요청 사용자의 소유인지 검증
  - 파일 id로 파일 검색(없다면 추가) -> 피그마 객체 가져오기 -> `Authority`에서 권한 확인 (없다면 추가)

## 📸 스크린샷(선택)

## 📝 기타
