### PR TITLE
[Feat] 연동된 피그마 계정 조회, 연동 해제 기능 구현

### DIFF
--- a/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
+++ b/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
@@ -1,10 +1,13 @@
 package gigedi.dev.domain.auth.api;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import gigedi.dev.domain.auth.application.AuthService;
 import gigedi.dev.domain.auth.dto.request.TokenRefreshRequest;
+import gigedi.dev.domain.auth.dto.response.FigmaAccountResponse;
 import gigedi.dev.domain.auth.dto.response.TokenPairResponse;
 import gigedi.dev.domain.auth.dto.response.UserInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,6 +31,19 @@ public class AuthController {
     @GetMapping("/code/figma")
     public UserInfoResponse figmaSocialLogin(@RequestParam String code) {
         return authService.figmaSocialLogin(code);
+    }
+
+    @Operation(summary = "연동된 피그마 계정 조회", description = "연동된 피그마 계정을 조회하는 API")
+    @GetMapping("/figma")
+    public List<FigmaAccountResponse> getFigmaAccount() {
+        return authService.getFigmaAccount();
+    }
+
+    @Operation(summary = "연동된 피그마 계정 삭제", description = "연동된 피그마 계정을 삭제하는 API")
+    @DeleteMapping("/figma/disconnect")
+    public ResponseEntity<Void> disconnectFigmaAccount() {
+        authService.disconnectFigmaAccount();
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "토큰 재발급", description = "엑세스 토큰 및 리프테시 토큰을 모두 재발급합니다.")

--- a/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
+++ b/src/main/java/gigedi/dev/domain/auth/api/AuthController.java
@@ -41,8 +41,8 @@ public class AuthController {
 
     @Operation(summary = "연동된 피그마 계정 삭제", description = "연동된 피그마 계정을 삭제하는 API")
     @DeleteMapping("/figma/disconnect")
-    public ResponseEntity<Void> disconnectFigmaAccount() {
-        authService.disconnectFigmaAccount();
+    public ResponseEntity<Void> disconnectFigmaAccount(@RequestParam Long figmaId) {
+        authService.deleteFigmaAccount(figmaId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
@@ -1,5 +1,7 @@
 package gigedi.dev.domain.auth.application;
 
+import java.util.List;
+
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +11,7 @@ import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.auth.dto.AccessTokenDto;
 import gigedi.dev.domain.auth.dto.RefreshTokenDto;
 import gigedi.dev.domain.auth.dto.request.TokenRefreshRequest;
+import gigedi.dev.domain.auth.dto.response.FigmaAccountResponse;
 import gigedi.dev.domain.auth.dto.response.GoogleLoginResponse;
 import gigedi.dev.domain.auth.dto.response.TokenPairResponse;
 import gigedi.dev.domain.auth.dto.response.UserInfoResponse;
@@ -57,6 +60,22 @@ public class AuthService {
                         userInfo.userId(),
                         member);
         figmaRepository.save(figma);
+    }
+
+    public List<FigmaAccountResponse> getFigmaAccount() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        List<Figma> figmaList = figmaRepository.findByMember(currentMember);
+        if (figmaList.isEmpty()) {
+            throw new CustomException(ErrorCode.FIGMA_ACCOUNT_NOT_FOUND);
+        }
+        return figmaList.stream()
+                .map(figma -> new FigmaAccountResponse(figma.getFigmaUserId(), figma.getEmail()))
+                .toList();
+    }
+
+    public void disconnectFigmaAccount() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        figmaRepository.deleteByMember(currentMember);
     }
 
     public TokenPairResponse refreshToken(TokenRefreshRequest request) {

--- a/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
@@ -64,7 +64,7 @@ public class AuthService {
 
     public List<FigmaAccountResponse> getFigmaAccount() {
         final Member currentMember = memberUtil.getCurrentMember();
-        List<Figma> figmaList = figmaRepository.findByMember(currentMember);
+        List<Figma> figmaList = figmaRepository.findByMemberAndDeletedAtIsNull(currentMember);
         if (figmaList.isEmpty()) {
             throw new CustomException(ErrorCode.FIGMA_ACCOUNT_NOT_FOUND);
         }
@@ -73,9 +73,13 @@ public class AuthService {
                 .toList();
     }
 
-    public void disconnectFigmaAccount() {
-        final Member currentMember = memberUtil.getCurrentMember();
-        figmaRepository.deleteByMember(currentMember);
+    @Transactional
+    public void deleteFigmaAccount(Long figmaId) {
+        Figma figma =
+                figmaRepository
+                        .findByIdAndDeletedAtIsNull(figmaId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_ACCOUNT_NOT_FOUND));
+        figma.deleteFigmaAccount();
     }
 
     public TokenPairResponse refreshToken(TokenRefreshRequest request) {

--- a/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
@@ -65,9 +65,6 @@ public class AuthService {
     public List<FigmaAccountResponse> getFigmaAccount() {
         final Member currentMember = memberUtil.getCurrentMember();
         List<Figma> figmaList = figmaRepository.findByMemberAndDeletedAtIsNull(currentMember);
-        if (figmaList.isEmpty()) {
-            throw new CustomException(ErrorCode.FIGMA_ACCOUNT_NOT_FOUND);
-        }
         return figmaList.stream()
                 .map(figma -> new FigmaAccountResponse(figma.getFigmaUserId(), figma.getEmail()))
                 .toList();

--- a/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
@@ -77,7 +77,7 @@ public class AuthService {
     public void deleteFigmaAccount(Long figmaId) {
         Figma figma =
                 figmaRepository
-                        .findByIdAndDeletedAtIsNull(figmaId)
+                        .findByFigmaIdAndDeletedAtIsNull(figmaId)
                         .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_ACCOUNT_NOT_FOUND));
         figma.deleteFigmaAccount();
     }

--- a/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
+++ b/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
@@ -1,15 +1,19 @@
 package gigedi.dev.domain.auth.dao;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import gigedi.dev.domain.auth.domain.Figma;
+import gigedi.dev.domain.member.domain.Member;
 
 @Repository
 public interface FigmaRepository extends JpaRepository<Figma, Long> {
     Optional<Figma> findByMemberId(Long memberId);
+
+    List<Figma> findByMember(Member member);
 
     Optional<Figma> findByFigmaUserId(String figmaUserId);
 }

--- a/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
+++ b/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
@@ -15,7 +15,7 @@ public interface FigmaRepository extends JpaRepository<Figma, Long> {
 
     List<Figma> findByMemberAndDeletedAtIsNull(Member member);
 
-    Optional<Figma> findByIdAndDeletedAtIsNull(Long figmaId);
+    Optional<Figma> findByFigmaIdAndDeletedAtIsNull(Long figmaId);
 
     Optional<Figma> findByFigmaUserId(String figmaUserId);
 }

--- a/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
+++ b/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
@@ -13,7 +13,9 @@ import gigedi.dev.domain.member.domain.Member;
 public interface FigmaRepository extends JpaRepository<Figma, Long> {
     Optional<Figma> findByMemberId(Long memberId);
 
-    List<Figma> findByMember(Member member);
+    List<Figma> findByMemberAndDeletedAtIsNull(Member member);
+
+    Optional<Figma> findByIdAndDeletedAtIsNull(Long figmaId);
 
     Optional<Figma> findByFigmaUserId(String figmaUserId);
 }

--- a/src/main/java/gigedi/dev/domain/auth/domain/Figma.java
+++ b/src/main/java/gigedi/dev/domain/auth/domain/Figma.java
@@ -38,8 +38,7 @@ public class Figma extends BaseTimeEntity {
     @Column(nullable = false)
     private String figmaUserId;
 
-    @Column(nullable = true)
-    private LocalDateTime deletedAt;
+    @Column private LocalDateTime deletedAt;
 
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/gigedi/dev/domain/auth/domain/Figma.java
+++ b/src/main/java/gigedi/dev/domain/auth/domain/Figma.java
@@ -1,5 +1,7 @@
 package gigedi.dev.domain.auth.domain;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -36,12 +38,19 @@ public class Figma extends BaseTimeEntity {
     @Column(nullable = false)
     private String figmaUserId;
 
+    @Column(nullable = true)
+    private LocalDateTime deletedAt;
+
     private String accessToken;
     private String refreshToken;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memeber_id")
     private Member member;
+
+    public void deleteFigmaAccount() {
+        this.deletedAt = LocalDateTime.now();
+    }
 
     @Builder(access = AccessLevel.PRIVATE)
     private Figma(

--- a/src/main/java/gigedi/dev/domain/auth/dto/response/FigmaAccountResponse.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/response/FigmaAccountResponse.java
@@ -1,0 +1,3 @@
+package gigedi.dev.domain.auth.dto.response;
+
+public record FigmaAccountResponse(String figmaId, String email) {}

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     FIGMA_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "Figma 로그인 과정에서 오류가 발생했습니다."),
     FIGMA_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "피그마 유저 정보를 불러오는 데 실패했습니다."),
     FIGMA_USER_INFO_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 피그마 유저 정보가 없습니다."),
+    FIGMA_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST, "피그마 계정을 찾을 수 없습니다."),
 
     // 추가
     GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "구글 로그인 과정에서 오류가 발생했습니다."),


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #44

## 💡 작업내용
**1. 연동된 피그마 계정 조회**
 - memberUtil을 사용해서 해당 유저의 피그마 계정 리스트 반환
 
**2. 피그마 계정 연동 해제 기능 구현**
- figmaId를 쿼리 파라미터로 받아 해당 피그마 계정을 soft delete 
- deletedAt 필드 추가했습니다.

## 📸 스크린샷(선택)

## 📝 기타
- 연동 해제 기능은 테스트했는데, 로컬에서 memberUtil이 안 되는 이슈가 아직 해결이 안 돼서 배포된 서버로 피그마 계정 조회 테스트하겠습니다.
- 피그마 도메인을 따로 뺄까 했는데, 피그마 로그인을 제외하면 2개가 다여서 그대로 Auth에서 작업했습니다.
