### PR TITLE
[Feat] 디스코드 계정 연결 해제 

### DIFF
--- a/src/main/java/gigedi/dev/domain/discord/api/DiscordAuthController.java
+++ b/src/main/java/gigedi/dev/domain/discord/api/DiscordAuthController.java
@@ -23,4 +23,10 @@ public class DiscordAuthController {
     public DiscordInfoResponse discordSocialLogin(@RequestParam String code) {
         return discordAuthService.discordConnect(code);
     }
+
+    @Operation(summary = "디스코드 연결 해제", description = "디스코드 연결을 해제하는 API")
+    @GetMapping("/discord/disconnect/{discordId}")
+    public void discordSocialLogin(@RequestParam Long discordId) {
+        discordAuthService.discordDisconnect(discordId);
+    }
 }

--- a/src/main/java/gigedi/dev/domain/discord/api/DiscordAuthController.java
+++ b/src/main/java/gigedi/dev/domain/discord/api/DiscordAuthController.java
@@ -1,9 +1,6 @@
 package gigedi.dev.domain.discord.api;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import gigedi.dev.domain.discord.application.DiscordAuthService;
 import gigedi.dev.domain.discord.dto.response.DiscordInfoResponse;
@@ -26,7 +23,7 @@ public class DiscordAuthController {
 
     @Operation(summary = "디스코드 연결 해제", description = "디스코드 연결을 해제하는 API")
     @GetMapping("/discord/disconnect/{discordId}")
-    public void discordSocialLogin(@RequestParam Long discordId) {
+    public void discordSocialLogin(@PathVariable Long discordId) {
         discordAuthService.discordDisconnect(discordId);
     }
 }

--- a/src/main/java/gigedi/dev/domain/discord/application/DiscordAuthApiService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/DiscordAuthApiService.java
@@ -99,4 +99,32 @@ public class DiscordAuthApiService {
             throw new CustomException(ErrorCode.DISCORD_TOKEN_REISSUE_FAILED);
         }
     }
+
+    public void disconnectDiscordAccount(String accessToken) {
+        try {
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add(CLIENT_ID_KEY, discordProperties.id());
+            formData.add(CLIENT_ID_SECRET, discordProperties.secret());
+            formData.add("token", accessToken);
+
+            restClient
+                    .post()
+                    .uri(DISCORD_DISCONNECT_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(
+                            status -> !status.is2xxSuccessful(),
+                            (request, response) -> {
+                                log.error("Discord 연결 해제 실패: {}", response.getStatusCode());
+                                throw new CustomException(ErrorCode.DISCORD_DISCONNECT_FAILED);
+                            })
+                    .toBodilessEntity();
+
+            log.info("Discord 연결 해제 성공");
+        } catch (Exception e) {
+            log.error("Discord 연결 해제 중 예외 발생: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.DISCORD_DISCONNECT_FAILED);
+        }
+    }
 }

--- a/src/main/java/gigedi/dev/domain/discord/application/DiscordAuthApiService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/DiscordAuthApiService.java
@@ -11,6 +11,7 @@ import org.springframework.web.client.RestClient;
 
 import gigedi.dev.domain.discord.dto.response.DiscordLoginResponse;
 import gigedi.dev.domain.discord.dto.response.DiscordUserResponse;
+import gigedi.dev.domain.discord.dto.response.ReissueDiscordTokenResponse;
 import gigedi.dev.global.error.exception.CustomException;
 import gigedi.dev.global.error.exception.ErrorCode;
 import gigedi.dev.infra.config.oauth.DiscordProperties;
@@ -35,7 +36,7 @@ public class DiscordAuthApiService {
 
             return restClient
                     .post()
-                    .uri(DISCORD_ID_TOKEN_URL)
+                    .uri(DISCORD_TOKEN_URL)
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                     .body(formData)
                     .retrieve()
@@ -69,6 +70,33 @@ public class DiscordAuthApiService {
         } catch (Exception e) {
             log.error("Discord 사용자 정보 조회 중 예외 발생: {}", e.getMessage(), e);
             throw new CustomException(ErrorCode.DISCORD_USER_INFO_FAILED);
+        }
+    }
+
+    public ReissueDiscordTokenResponse reissueDiscordToken(String refreshToken) {
+        try {
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add(CLIENT_ID_KEY, discordProperties.id());
+            formData.add(CLIENT_ID_SECRET, discordProperties.secret());
+            formData.add(GRANT_TYPE_KEY, REISSUE_GRANT_TYPE_VALUE);
+            formData.add(REFRESH_TOKEN, refreshToken);
+
+            return restClient
+                    .post()
+                    .uri(DISCORD_TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(
+                            status -> !status.is2xxSuccessful(),
+                            (request, response) -> {
+                                log.error("Discord 토큰 갱신 실패: {}", response.getStatusCode());
+                                throw new CustomException(ErrorCode.DISCORD_TOKEN_REISSUE_FAILED);
+                            })
+                    .body(ReissueDiscordTokenResponse.class);
+        } catch (Exception e) {
+            log.error("Discord 토큰 갱신 중 예외 발생: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.DISCORD_TOKEN_REISSUE_FAILED);
         }
     }
 }

--- a/src/main/java/gigedi/dev/domain/discord/application/DiscordAuthService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/DiscordAuthService.java
@@ -5,11 +5,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import gigedi.dev.domain.discord.dao.DiscordRepository;
 import gigedi.dev.domain.discord.domain.Discord;
-import gigedi.dev.domain.discord.dto.response.CreateDMChannelResponse;
-import gigedi.dev.domain.discord.dto.response.DiscordInfoResponse;
-import gigedi.dev.domain.discord.dto.response.DiscordLoginResponse;
-import gigedi.dev.domain.discord.dto.response.DiscordUserResponse;
+import gigedi.dev.domain.discord.dto.response.*;
 import gigedi.dev.domain.member.domain.Member;
+import gigedi.dev.global.error.exception.CustomException;
+import gigedi.dev.global.error.exception.ErrorCode;
 import gigedi.dev.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 
@@ -50,5 +49,25 @@ public class DiscordAuthService {
                         dmChannel.id(),
                         loginResponse.getGuildId());
         return DiscordInfoResponse.from(discordRepository.save(discord));
+    }
+
+    public void discordDisconnect(Long discordId) {
+        Discord discordById = findDiscordById(discordId);
+        ReissueDiscordTokenResponse tokenResponse =
+                discordAuthApiService.reissueDiscordToken(discordById.getRefreshToken());
+        discordById.updateRefreshToken(tokenResponse.refreshToken());
+    }
+
+    private Discord findDiscordById(Long discordId) {
+        Member currentMember = memberUtil.getCurrentMember();
+        Discord discord =
+                discordRepository
+                        .findById(discordId)
+                        .orElseThrow(
+                                () -> new CustomException(ErrorCode.DISCORD_ACCOUNT_NOT_FOUND));
+        if (!discord.getMember().equals(currentMember)) {
+            throw new CustomException(ErrorCode.DISCORD_ACCOUNT_NOT_OWNER);
+        }
+        return discord;
     }
 }

--- a/src/main/java/gigedi/dev/domain/discord/application/DiscordAuthService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/DiscordAuthService.java
@@ -56,6 +56,9 @@ public class DiscordAuthService {
         ReissueDiscordTokenResponse tokenResponse =
                 discordAuthApiService.reissueDiscordToken(discordById.getRefreshToken());
         discordById.updateRefreshToken(tokenResponse.refreshToken());
+
+        discordAuthApiService.disconnectDiscordAccount(tokenResponse.accessToken());
+        discordById.disconnectDiscordAccount();
     }
 
     private Discord findDiscordById(Long discordId) {

--- a/src/main/java/gigedi/dev/domain/discord/domain/Discord.java
+++ b/src/main/java/gigedi/dev/domain/discord/domain/Discord.java
@@ -83,4 +83,8 @@ public class Discord extends BaseTimeEntity {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void disconnectDiscordAccount() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/gigedi/dev/domain/discord/domain/Discord.java
+++ b/src/main/java/gigedi/dev/domain/discord/domain/Discord.java
@@ -79,4 +79,8 @@ public class Discord extends BaseTimeEntity {
                 .guildId(guildId)
                 .build();
     }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/gigedi/dev/domain/discord/dto/response/ReissueDiscordTokenResponse.java
+++ b/src/main/java/gigedi/dev/domain/discord/dto/response/ReissueDiscordTokenResponse.java
@@ -1,0 +1,7 @@
+package gigedi.dev.domain.discord.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ReissueDiscordTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken) {}

--- a/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
+++ b/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
@@ -22,6 +22,8 @@ public final class SecurityConstants {
     public static final String DISCORD_CREATE_DM_CHANNEL_URL =
             "https://discord.com/api/v9/users/@me/channels";
     public static final String DISCORD_GUILD_URL = "https://discord.com/api/v10/guilds";
+    public static final String DISCORD_DISCONNECT_URL =
+            "https://discord.com/api/oauth2/token/revoke";
 
     public static final String FIGMA_GET_ID_TOKEN_URL = "https://www.figma.com/api/oauth/token";
     public static final String FIGMA_GET_USER_INFO_URL = "https://api.figma.com/v1/me";

--- a/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
+++ b/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
@@ -17,7 +17,7 @@ public final class SecurityConstants {
     public static final String GOOGLE_WITHDRAWAL_URL =
             "https://accounts.google.com/o/oauth2/revoke?token=";
 
-    public static final String DISCORD_ID_TOKEN_URL = "https://discord.com/api/oauth2/token";
+    public static final String DISCORD_TOKEN_URL = "https://discord.com/api/oauth2/token";
     public static final String DISCORD_USER_INFO_URL = "https://discord.com/api/users/@me";
     public static final String DISCORD_CREATE_DM_CHANNEL_URL =
             "https://discord.com/api/v9/users/@me/channels";

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -55,6 +55,9 @@ public enum ErrorCode {
     DISCORD_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "디스코드 사용자 정보 조회에 실패했습니다."),
     DISCORD_DM_CHANNEL_CREATION_FAILED(HttpStatus.BAD_REQUEST, "디스코드 DM 채널 생성에 실패했습니다."),
     DISCORD_GUILD_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "디스코드 길드 설정에 실패했습니다."),
+    DISCORD_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 디스코드 계정이 존재하지 않습니다."),
+    DISCORD_ACCOUNT_NOT_OWNER(HttpStatus.NOT_FOUND, "해당 디스코드 계정의 소유자가 아닙니다."),
+    DISCORD_TOKEN_REISSUE_FAILED(HttpStatus.BAD_REQUEST, "디스코드 토큰 재발급 과정에서 오류가 발생했습니다."),
 
     // 추가
     GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "구글 로그인 과정에서 오류가 발생했습니다."),

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     DISCORD_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 디스코드 계정이 존재하지 않습니다."),
     DISCORD_ACCOUNT_NOT_OWNER(HttpStatus.NOT_FOUND, "해당 디스코드 계정의 소유자가 아닙니다."),
     DISCORD_TOKEN_REISSUE_FAILED(HttpStatus.BAD_REQUEST, "디스코드 토큰 재발급 과정에서 오류가 발생했습니다."),
+    DISCORD_DISCONNECT_FAILED(HttpStatus.BAD_REQUEST, "디스코드 연결 해제 과정에서 오류가 발생했습니다."),
 
     // 추가
     GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "구글 로그인 과정에서 오류가 발생했습니다."),


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #47 

## 💡 작업내용
### 디스코드 엑세스 토큰 재발급
- 계정 연결 해제의 텀을 예측할 수 없어 필수적으로 리프레시토큰으로 엑세스토큰이 발급되도록 하였습니다.
- 리프레시 토큰으로 재발급 시 리프레시 토큰까지 재발급되기 때문에 연결 해제가 실패할 경우를 대비하여 디스코드 객체에 리프레시 토큰이 업데이트되도록 설정 했습니다. 

### 디스코드 연결 해제 로직 구현
- `deletedAt` 필드를 갱신하여 소프트 딜리트로 구현하였습니다. 

## 📸 스크린샷(선택)

## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
