### PR TITLE
[Feat] 디스코드 계정 개수 제한 적용

### DIFF
--- a/src/main/java/gigedi/dev/domain/discord/api/DiscordAuthController.java
+++ b/src/main/java/gigedi/dev/domain/discord/api/DiscordAuthController.java
@@ -22,8 +22,8 @@ public class DiscordAuthController {
     }
 
     @Operation(summary = "디스코드 연결 해제", description = "디스코드 연결을 해제하는 API")
-    @GetMapping("/discord/disconnect/{discordId}")
-    public void discordSocialLogin(@PathVariable Long discordId) {
-        discordAuthService.discordDisconnect(discordId);
+    @GetMapping("/discord/disconnect")
+    public void discordSocialLogin() {
+        discordAuthService.discordDisconnect();
     }
 }

--- a/src/main/java/gigedi/dev/domain/discord/application/DiscordService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/DiscordService.java
@@ -1,0 +1,42 @@
+package gigedi.dev.domain.discord.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gigedi.dev.domain.discord.dao.DiscordRepository;
+import gigedi.dev.domain.discord.domain.Discord;
+import gigedi.dev.domain.member.domain.Member;
+import gigedi.dev.global.error.exception.CustomException;
+import gigedi.dev.global.error.exception.ErrorCode;
+import gigedi.dev.global.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DiscordService {
+    private final MemberUtil memberUtil;
+    private final DiscordRepository discordRepository;
+
+    public Discord saveDiscord(Discord discord) {
+        return discordRepository.save(discord);
+    }
+
+    public Discord findConnectedDiscord() {
+        Member currentMember = memberUtil.getCurrentMember();
+        return discordRepository
+                .findByMember(currentMember)
+                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_ACCOUNT_NOT_FOUND));
+    }
+
+    public void deleteDiscord(Discord discord) {
+        discordRepository.delete(discord);
+    }
+
+    public void validateDiscordExistsForMember() {
+        Member currentMember = memberUtil.getCurrentMember();
+        if (discordRepository.findByMember(currentMember).isPresent()) {
+            throw new CustomException(ErrorCode.DISCORD_ACCOUNT_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/gigedi/dev/domain/discord/dao/DiscordRepository.java
+++ b/src/main/java/gigedi/dev/domain/discord/dao/DiscordRepository.java
@@ -1,9 +1,14 @@
 package gigedi.dev.domain.discord.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import gigedi.dev.domain.discord.domain.Discord;
+import gigedi.dev.domain.member.domain.Member;
 
 @Repository
-public interface DiscordRepository extends JpaRepository<Discord, Long> {}
+public interface DiscordRepository extends JpaRepository<Discord, Long> {
+    Optional<Discord> findByMember(Member member);
+}

--- a/src/main/java/gigedi/dev/domain/discord/domain/Discord.java
+++ b/src/main/java/gigedi/dev/domain/discord/domain/Discord.java
@@ -1,15 +1,6 @@
 package gigedi.dev.domain.discord.domain;
 
-import java.time.LocalDateTime;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 
 import gigedi.dev.domain.config.BaseTimeEntity;
 import gigedi.dev.domain.member.domain.Member;
@@ -29,8 +20,6 @@ public class Discord extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
-    private LocalDateTime deletedAt;
-
     @Column(nullable = false)
     private String dmChannel;
 
@@ -43,7 +32,7 @@ public class Discord extends BaseTimeEntity {
     @Column(nullable = false)
     private String guildId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
@@ -82,9 +71,5 @@ public class Discord extends BaseTimeEntity {
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
-    }
-
-    public void disconnectDiscordAccount() {
-        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
     DISCORD_ACCOUNT_NOT_OWNER(HttpStatus.NOT_FOUND, "해당 디스코드 계정의 소유자가 아닙니다."),
     DISCORD_TOKEN_REISSUE_FAILED(HttpStatus.BAD_REQUEST, "디스코드 토큰 재발급 과정에서 오류가 발생했습니다."),
     DISCORD_DISCONNECT_FAILED(HttpStatus.BAD_REQUEST, "디스코드 연결 해제 과정에서 오류가 발생했습니다."),
+    DISCORD_ACCOUNT_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "연결된 디스코드 계정이 이미 존재합니다."),
 
     // 추가
     GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "구글 로그인 과정에서 오류가 발생했습니다."),


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #52

## 💡 작업내용
### 디스코드 개정 개수 1개로 제한 수정
- 사용자당 하나의 계정만 존재하기 때문에 `OneToOne` 관계로 전환하고 하드 딜리트 구현으로 변경하였습니다.
- 연결 시 이미 연결이 존재한다면 예외를 반환합니다.
- 어떤 디스코드인지 필요하지 않게됨에 따라 컨트롤러의 경로변수 로직을 제거하였습니다.

### 디스코드 서비스 클래스 분리 구현
- 디스코드 레포지토리와 연결되는 도메인 서비스 로직을 따로 구현하였습니다. 

### 디스코드 인가코드 디코딩
- 구글과 같은 오류가 발생하여 디코딩 로직을 추가하였습니다. 

## 📸 스크린샷(선택)

## 📝 기타

