### PR TITLE
[Feat] 디스코드 알람 파일 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Querydsl ###
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
 
 	// QueryDSL
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	implementation "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -137,6 +141,7 @@ spotless {
 		removeUnusedImports()
 		trimTrailingWhitespace()
 		endWithNewline()
+		targetExclude("src/main/generated/**/*.java")
 	}
 }
 
@@ -161,4 +166,18 @@ tasks.register('makeGitHooksExecutable', Exec) {
 
 tasks.withType(JavaCompile) {
 	dependsOn("makeGitHooksExecutable")
+}
+
+def querydslDir = 'src/main/generated'
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean {
+	delete file(querydslDir)
 }

--- a/src/main/java/gigedi/dev/domain/discord/api/AlarmController.java
+++ b/src/main/java/gigedi/dev/domain/discord/api/AlarmController.java
@@ -1,0 +1,25 @@
+package gigedi.dev.domain.discord.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import gigedi.dev.domain.discord.application.AlarmService;
+import gigedi.dev.domain.discord.dto.response.GetAlarmFileListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Alarm", description = "Alarm 관련 API")
+@RestController
+@RequestMapping("/api/v1/alarm")
+@RequiredArgsConstructor
+public class AlarmController {
+    private final AlarmService alarmService;
+
+    @Operation(summary = "알람 정보 파일 조회", description = "알람이 설정되어있는 파일 리스틀를 조회하는 API")
+    @GetMapping("/discord")
+    public GetAlarmFileListResponse discordSocialLogin() {
+        return alarmService.getAlarmFileList();
+    }
+}

--- a/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
@@ -1,0 +1,34 @@
+package gigedi.dev.domain.discord.application;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gigedi.dev.domain.discord.domain.Discord;
+import gigedi.dev.domain.discord.dto.response.AlarmFileResponse;
+import gigedi.dev.domain.discord.dto.response.GetAlarmFileListResponse;
+import gigedi.dev.domain.file.application.AuthorityService;
+import gigedi.dev.domain.member.domain.Member;
+import gigedi.dev.global.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AlarmService {
+    private final DiscordService discordService;
+    private final AuthorityService authorityService;
+    private final MemberUtil memberUtil;
+
+    public GetAlarmFileListResponse getAlarmFileList() {
+        Member currentMember = memberUtil.getCurrentMember();
+        Discord connectedDiscord = discordService.findConnectedDiscord();
+        List<AlarmFileResponse> alarmList =
+                authorityService.getRelatedAuthorityList(currentMember.getId()).stream()
+                        .map(AlarmFileResponse::from)
+                        .collect(Collectors.toList());
+        return new GetAlarmFileListResponse(connectedDiscord.getEmail(), alarmList);
+    }
+}

--- a/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import gigedi.dev.domain.discord.domain.Discord;
 import gigedi.dev.domain.discord.dto.response.AlarmFileResponse;
@@ -15,7 +14,6 @@ import gigedi.dev.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class AlarmService {
     private final DiscordService discordService;

--- a/src/main/java/gigedi/dev/domain/discord/application/DiscordService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/DiscordService.java
@@ -12,16 +12,17 @@ import gigedi.dev.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class DiscordService {
     private final MemberUtil memberUtil;
     private final DiscordRepository discordRepository;
 
+    @Transactional
     public Discord saveDiscord(Discord discord) {
         return discordRepository.save(discord);
     }
 
+    @Transactional(readOnly = true)
     public Discord findConnectedDiscord() {
         Member currentMember = memberUtil.getCurrentMember();
         return discordRepository
@@ -29,10 +30,12 @@ public class DiscordService {
                 .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_ACCOUNT_NOT_FOUND));
     }
 
+    @Transactional
     public void deleteDiscord(Discord discord) {
         discordRepository.delete(discord);
     }
 
+    @Transactional(readOnly = true)
     public void validateDiscordExistsForMember() {
         Member currentMember = memberUtil.getCurrentMember();
         if (discordRepository.findByMember(currentMember).isPresent()) {

--- a/src/main/java/gigedi/dev/domain/discord/dto/response/AlarmFileResponse.java
+++ b/src/main/java/gigedi/dev/domain/discord/dto/response/AlarmFileResponse.java
@@ -1,0 +1,10 @@
+package gigedi.dev.domain.discord.dto.response;
+
+import gigedi.dev.domain.file.domain.Authority;
+
+public record AlarmFileResponse(Long authorityId, String fileName, boolean isAlarmActive) {
+    public static AlarmFileResponse from(Authority authority) {
+        return new AlarmFileResponse(
+                authority.getAuthorityId(), authority.getFile().getFileName(), authority.isAlarm());
+    }
+}

--- a/src/main/java/gigedi/dev/domain/discord/dto/response/GetAlarmFileListResponse.java
+++ b/src/main/java/gigedi/dev/domain/discord/dto/response/GetAlarmFileListResponse.java
@@ -1,0 +1,5 @@
+package gigedi.dev.domain.discord.dto.response;
+
+import java.util.List;
+
+public record GetAlarmFileListResponse(String discordEmail, List<AlarmFileResponse> alarmList) {}

--- a/src/main/java/gigedi/dev/domain/file/application/AuthorityService.java
+++ b/src/main/java/gigedi/dev/domain/file/application/AuthorityService.java
@@ -1,0 +1,21 @@
+package gigedi.dev.domain.file.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gigedi.dev.domain.file.dao.AuthorityRepository;
+import gigedi.dev.domain.file.domain.Authority;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthorityService {
+    private final AuthorityRepository authorityRepository;
+
+    @Transactional(readOnly = true)
+    public List<Authority> getRelatedAuthorityList(Long memberId) {
+        return authorityRepository.findRelatedAuthorities(memberId);
+    }
+}

--- a/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepository.java
+++ b/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepository.java
@@ -10,6 +10,7 @@ import gigedi.dev.domain.file.domain.Authority;
 import gigedi.dev.domain.file.domain.File;
 
 @Repository
-public interface AuthorityRepository extends JpaRepository<Authority, Long> {
+public interface AuthorityRepository
+        extends JpaRepository<Authority, Long>, AuthorityRepositoryCustom {
     Optional<Authority> findByFigmaAndFile(Figma figma, File file);
 }

--- a/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryCustom.java
+++ b/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryCustom.java
@@ -1,0 +1,9 @@
+package gigedi.dev.domain.file.dao;
+
+import java.util.List;
+
+import gigedi.dev.domain.file.domain.Authority;
+
+public interface AuthorityRepositoryCustom {
+    List<Authority> findRelatedAuthorities(Long memberId);
+}

--- a/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryImpl.java
+++ b/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryImpl.java
@@ -1,0 +1,31 @@
+package gigedi.dev.domain.file.dao;
+
+import java.util.List;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import gigedi.dev.domain.auth.domain.QFigma;
+import gigedi.dev.domain.file.domain.Authority;
+import gigedi.dev.domain.file.domain.QAuthority;
+import gigedi.dev.domain.member.domain.QMember;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthorityRepositoryImpl implements AuthorityRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Authority> findRelatedAuthorities(Long memberId) {
+        return queryFactory
+                .selectFrom(QAuthority.authority)
+                .join(QAuthority.authority.figma, QFigma.figma)
+                .join(QFigma.figma.member, QMember.member)
+                .where(
+                        QMember.member
+                                .id
+                                .eq(memberId)
+                                .and(QMember.member.deletedAt.isNull())
+                                .and(QFigma.figma.deletedAt.isNull()))
+                .fetch();
+    }
+}

--- a/src/main/java/gigedi/dev/domain/member/domain/Member.java
+++ b/src/main/java/gigedi/dev/domain/member/domain/Member.java
@@ -18,7 +18,7 @@ public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
-    private Long Id;
+    private Long id;
 
     @Embedded private OauthInfo oauthInfo;
 

--- a/src/main/java/gigedi/dev/global/util/MemberUtil.java
+++ b/src/main/java/gigedi/dev/global/util/MemberUtil.java
@@ -1,6 +1,7 @@
 package gigedi.dev.global.util;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import gigedi.dev.domain.member.dao.MemberRepository;
 import gigedi.dev.domain.member.domain.Member;
@@ -15,6 +16,7 @@ public class MemberUtil {
     private final SecurityUtil securityUtil;
     private final MemberRepository memberRepository;
 
+    @Transactional(readOnly = true)
     public Member getCurrentMember() {
         return memberRepository
                 .findById(securityUtil.getCurrentMemberId())


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #49 

## 💡 작업내용
### Querydsl 추가 설정
- Q객체가 생기지 않아 추가적인 설정을 진행했습니다.

### 디스코드 알람 파일 조회
- 조인을 하는 과정에서 쿼리가 너무 길어져 querydsl로 구성하는 것이 좋겠다는 판단에 querydsl로 구성하였습니다.
- 알람에 관련된 동작이기에 따로 클래스를 만들었습니다.
- 이후 알람 설정 변경 시 `authorityId`로 주는 것이 조인과정을 거치지 않아 더 빠를거 같아 `fileId`가 아닌 `authorityId`를 반환하도록 설정하였습니다. 
- 피그마 페이지가 아닌 파일이기에 그렇게 많은 파일이 발생할 것 같지 않다는 판단에 페이징을 적용하지는 않았습니다. 이후 추가적인 기준이 생긴다면 페이징을 적용할 수 있을 것 같습니다. 

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/8392143b-544b-4061-b599-dc5dbcae1cac)
- 마지막의 경우 다른 피그마 계정의 파일로 멤버와 연결된 모든 파일 정보가 잘 조회되는 것을 확인할 수 있습니다. 

## 📝 기타
- 지금 제 코드는 제 생각으로만 디렉토리를 분리하여 구현하고 있는데 자세한 디렉토리 구조를 회의로 확정시키면 좋을 것 같습니다. 
