### PR TITLE
[Feat] 디스코드 파일 알람 활성화 및 비활성화

### DIFF
--- a/src/main/java/gigedi/dev/domain/discord/api/AlarmController.java
+++ b/src/main/java/gigedi/dev/domain/discord/api/AlarmController.java
@@ -1,10 +1,9 @@
 package gigedi.dev.domain.discord.api;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import gigedi.dev.domain.discord.application.AlarmService;
+import gigedi.dev.domain.discord.dto.response.AlarmFileResponse;
 import gigedi.dev.domain.discord.dto.response.GetAlarmFileListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,7 +18,19 @@ public class AlarmController {
 
     @Operation(summary = "알람 정보 파일 조회", description = "알람이 설정되어있는 파일 리스틀를 조회하는 API")
     @GetMapping("/discord")
-    public GetAlarmFileListResponse discordSocialLogin() {
+    public GetAlarmFileListResponse getAlarmFileList() {
         return alarmService.getAlarmFileList();
+    }
+
+    @Operation(summary = "알람 설정 활성화", description = "특정 파일의 알람을 활성화하는 API")
+    @PutMapping("/{fileId}/active")
+    public AlarmFileResponse activateFileAlarm(@PathVariable Long fileId) {
+        return alarmService.changeAlarmActive(fileId);
+    }
+
+    @Operation(summary = "알람 설정 비활성화", description = "특정 파일의 알람을 비활성화하는 API")
+    @PutMapping("/{fileId}/inactive")
+    public AlarmFileResponse inactiveFileAlarm(@PathVariable Long fileId) {
+        return alarmService.changeAlarmInactive(fileId);
     }
 }

--- a/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
@@ -4,11 +4,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.discord.domain.Discord;
 import gigedi.dev.domain.discord.dto.response.AlarmFileResponse;
 import gigedi.dev.domain.discord.dto.response.GetAlarmFileListResponse;
+import gigedi.dev.domain.figma.application.FigmaService;
 import gigedi.dev.domain.file.application.AuthorityService;
+import gigedi.dev.domain.file.domain.Authority;
 import gigedi.dev.domain.member.domain.Member;
 import gigedi.dev.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class AlarmService {
     private final DiscordService discordService;
     private final AuthorityService authorityService;
+    private final FigmaService figmaService;
     private final MemberUtil memberUtil;
 
     public GetAlarmFileListResponse getAlarmFileList() {
@@ -28,5 +33,25 @@ public class AlarmService {
                         .map(AlarmFileResponse::from)
                         .collect(Collectors.toList());
         return new GetAlarmFileListResponse(connectedDiscord.getEmail(), alarmList);
+    }
+
+    @Transactional
+    public AlarmFileResponse changeAlarmActive(Long fileId) {
+        Authority authority = getAuthorityByFileId(fileId);
+        authority.updateAlarmActive();
+        return AlarmFileResponse.from(authority);
+    }
+
+    @Transactional
+    public AlarmFileResponse changeAlarmInactive(Long fileId) {
+        Authority authority = getAuthorityByFileId(fileId);
+        authority.updateAlarmInactive();
+        return AlarmFileResponse.from(authority);
+    }
+
+    private Authority getAuthorityByFileId(Long fileId) {
+        Member currentMember = memberUtil.getCurrentMember();
+        List<Figma> figmaList = figmaService.getFigmaListByMember(currentMember);
+        return authorityService.getAuthorityByFileIdAndFigmaList(fileId, figmaList);
     }
 }

--- a/src/main/java/gigedi/dev/domain/discord/dto/response/AlarmFileResponse.java
+++ b/src/main/java/gigedi/dev/domain/discord/dto/response/AlarmFileResponse.java
@@ -5,6 +5,8 @@ import gigedi.dev.domain.file.domain.Authority;
 public record AlarmFileResponse(Long authorityId, String fileName, boolean isAlarmActive) {
     public static AlarmFileResponse from(Authority authority) {
         return new AlarmFileResponse(
-                authority.getAuthorityId(), authority.getFile().getFileName(), authority.isAlarm());
+                authority.getFile().getFileId(),
+                authority.getFile().getFileName(),
+                authority.isAlarm());
     }
 }

--- a/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
+++ b/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
@@ -13,17 +13,18 @@ import gigedi.dev.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class FigmaService {
     private final FigmaRepository figmaRepository;
 
+    @Transactional(readOnly = true)
     public void validateFigmaAccountAlreadyExists(String figmaId) {
         if (figmaRepository.findByFigmaUserIdAndDeletedAtIsNull(figmaId).isPresent()) {
             throw new CustomException(ErrorCode.FIGMA_ACCOUNT_ALREADY_CONNECTED);
         }
     }
 
+    @Transactional(readOnly = true)
     public Figma getFigmaByFigmaId(String figmaId) {
         return figmaRepository
                 .findByFigmaUserIdAndDeletedAtIsNull(figmaId)

--- a/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
+++ b/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
@@ -1,10 +1,13 @@
 package gigedi.dev.domain.figma.application;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import gigedi.dev.domain.auth.dao.FigmaRepository;
 import gigedi.dev.domain.auth.domain.Figma;
+import gigedi.dev.domain.member.domain.Member;
 import gigedi.dev.global.error.exception.CustomException;
 import gigedi.dev.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +28,10 @@ public class FigmaService {
         return figmaRepository
                 .findByFigmaUserIdAndDeletedAtIsNull(figmaId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_NOT_CONNECTED));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Figma> getFigmaListByMember(Member member) {
+        return figmaRepository.findByMemberAndDeletedAtIsNull(member);
     }
 }

--- a/src/main/java/gigedi/dev/domain/file/application/AuthorityService.java
+++ b/src/main/java/gigedi/dev/domain/file/application/AuthorityService.java
@@ -5,8 +5,11 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.file.dao.AuthorityRepository;
 import gigedi.dev.domain.file.domain.Authority;
+import gigedi.dev.global.error.exception.CustomException;
+import gigedi.dev.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -17,5 +20,12 @@ public class AuthorityService {
     @Transactional(readOnly = true)
     public List<Authority> getRelatedAuthorityList(Long memberId) {
         return authorityRepository.findRelatedAuthorities(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public Authority getAuthorityByFileIdAndFigmaList(Long fileId, List<Figma> figmaList) {
+        return authorityRepository
+                .findByFileAndActiveFigma(fileId, figmaList)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTHORITY_NOT_FOUND));
     }
 }

--- a/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryCustom.java
+++ b/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryCustom.java
@@ -1,9 +1,13 @@
 package gigedi.dev.domain.file.dao;
 
 import java.util.List;
+import java.util.Optional;
 
+import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.file.domain.Authority;
 
 public interface AuthorityRepositoryCustom {
     List<Authority> findRelatedAuthorities(Long memberId);
+
+    Optional<Authority> findByFileAndActiveFigma(Long fileId, List<Figma> figmaList);
 }

--- a/src/main/java/gigedi/dev/domain/file/domain/Authority.java
+++ b/src/main/java/gigedi/dev/domain/file/domain/Authority.java
@@ -44,4 +44,12 @@ public class Authority {
     public static Authority createAuthority(Figma figma, File file) {
         return Authority.builder().alarm(true).figma(figma).file(file).build();
     }
+
+    public void updateAlarmActive() {
+        this.alarm = true;
+    }
+
+    public void updateAlarmInactive() {
+        this.alarm = false;
+    }
 }

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -73,6 +73,9 @@ public enum ErrorCode {
     DISCORD_DISCONNECT_FAILED(HttpStatus.BAD_REQUEST, "디스코드 연결 해제 과정에서 오류가 발생했습니다."),
     DISCORD_ACCOUNT_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "연결된 디스코드 계정이 이미 존재합니다."),
 
+    // Authority
+    AUTHORITY_NOT_FOUND(HttpStatus.NOT_FOUND, "피그마 계정과 파일의 연관 정보가 존재하지 않습니다."),
+
     // 추가
     GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "구글 로그인 과정에서 오류가 발생했습니다."),
     GOOGLE_AUTH_NOT_FOUND(HttpStatus.BAD_REQUEST, "구글 리프레시 토큰이 존재하지 않습니다."),


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #62 

## 💡 작업내용
### 파일 알람 반환 응답 dto 수정
- 이전 구현에서는 성능을 위하여 `authorityId`를 사용했지만, 
   검증을 해야하기에 성능 상으로 거의 차이가 없고, RestFul 설계할 때는 자원 중심의 설계를 해야하기에 `fieId`로 변환하였습니다.

### 파일 알람 활성화 및 비활성화
- 저희 프로젝트가 소프트딜리트를 중심으로 사용하기 때문에 `isNull()`인 객체들의 조회를 해야함에 따라 쿼리가 늘어나 querydsl을 사용하였습니다. 
- 일반적으로 알람 설정은 엔티티의 속성 일부값만 변경하는 것이기에 PUT 메소드를 사용하는 것으로 변경했습니다. 

## 📸 스크린샷(선택)
<img src="https://github.com/user-attachments/assets/bae85d0c-3699-413d-b20b-27e0b007447d" width="45%">
<img src="https://github.com/user-attachments/assets/65a2071c-e930-4583-b02a-02271ed0aadc" width="45%">


## 📝 기타
