### PR TITLE
[Feat] Shoot 생성 API 구현, 상태 변경 수정

### DIFF
--- a/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
+++ b/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
@@ -18,4 +18,6 @@ public interface FigmaRepository extends JpaRepository<Figma, Long> {
     Optional<Figma> findByFigmaIdAndDeletedAtIsNull(Long figmaId);
 
     Optional<Figma> findByFigmaUserIdAndDeletedAtIsNull(String figmaUserId);
+
+    Optional<Figma> findByFigmaName(String name);
 }

--- a/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
+++ b/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
@@ -35,6 +35,8 @@ public class FigmaService {
         return figmaRepository
                 .findByFigmaName(tag)
                 .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_USER_INFO_NOT_FOUND));
+    }
+
     @Transactional(readOnly = true)
     public List<Figma> getFigmaListByMember(Member member) {
         return figmaRepository.findByMemberAndDeletedAtIsNull(member);

--- a/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
+++ b/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
@@ -26,4 +26,10 @@ public class FigmaService {
                 .findByFigmaUserIdAndDeletedAtIsNull(figmaId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_NOT_CONNECTED));
     }
+
+    public Figma findByTag(String tag) {
+        return figmaRepository
+                .findByFigmaName(tag)
+                .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_USER_INFO_NOT_FOUND));
+    }
 }

--- a/src/main/java/gigedi/dev/domain/shoot/api/ShootController.java
+++ b/src/main/java/gigedi/dev/domain/shoot/api/ShootController.java
@@ -6,11 +6,13 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import gigedi.dev.domain.shoot.application.ShootService;
+import gigedi.dev.domain.shoot.dto.request.CreateShootRequest;
 import gigedi.dev.domain.shoot.dto.request.UpdateShootStatusRequest;
 import gigedi.dev.domain.shoot.dto.response.GetShootResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,9 +45,10 @@ public class ShootController {
         return shootService.updateShootStatus(shootId, request.status());
     }
 
-    @Operation(summary = "Our Shoot 조회 API", description = "내 shoot status들을 조회하는 API")
-    @GetMapping("/status")
-    public List<GetShootResponse> getOurShoot() {
-        return shootService.getOurShoot();
+    @Operation(summary = "Shoot 생성 API", description = "Shoot을 생성하는 API")
+    @PostMapping("/{blockId}")
+    public GetShootResponse createShoot(
+            @PathVariable Long blockId, @RequestBody CreateShootRequest request) {
+        return shootService.createShoot(blockId, request.content());
     }
 }

--- a/src/main/java/gigedi/dev/domain/shoot/api/ShootController.java
+++ b/src/main/java/gigedi/dev/domain/shoot/api/ShootController.java
@@ -42,4 +42,10 @@ public class ShootController {
             @PathVariable Long shootId, @RequestBody UpdateShootStatusRequest request) {
         return shootService.updateShootStatus(shootId, request.status());
     }
+
+    @Operation(summary = "Our Shoot 조회 API", description = "내 shoot status들을 조회하는 API")
+    @GetMapping("/status")
+    public List<GetShootResponse> getOurShoot() {
+        return shootService.getOurShoot();
+    }
 }

--- a/src/main/java/gigedi/dev/domain/shoot/api/ShootController.java
+++ b/src/main/java/gigedi/dev/domain/shoot/api/ShootController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import gigedi.dev.domain.shoot.application.ShootService;
+import gigedi.dev.domain.shoot.application.ShootStatusService;
 import gigedi.dev.domain.shoot.dto.request.CreateShootRequest;
 import gigedi.dev.domain.shoot.dto.request.UpdateShootStatusRequest;
 import gigedi.dev.domain.shoot.dto.response.GetShootResponse;
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ShootController {
     private final ShootService shootService;
+    private final ShootStatusService shootStatusService;
 
     @Operation(summary = "Block 별 Shoot 조회 API", description = "Block 별 Shoot을 조회하는 API")
     @GetMapping("/{blockId}")
@@ -38,17 +40,17 @@ public class ShootController {
         shootService.deleteShoot(shootId);
     }
 
-    @Operation(summary = "Shoot 상태 변경 API", description = "Shoot의 상태(yet, doing, done)를 변경하는 API")
-    @PatchMapping("/status/{shootId}")
-    public GetShootResponse updateShootStatus(
-            @PathVariable Long shootId, @RequestBody UpdateShootStatusRequest request) {
-        return shootService.updateShootStatus(shootId, request.status());
-    }
-
     @Operation(summary = "Shoot 생성 API", description = "Shoot을 생성하는 API")
     @PostMapping("/{blockId}")
     public GetShootResponse createShoot(
             @PathVariable Long blockId, @RequestBody CreateShootRequest request) {
         return shootService.createShoot(blockId, request.content());
+    }
+
+    @Operation(summary = "Shoot 상태 변경 API", description = "Shoot의 상태(yet, doing, done)를 변경하는 API")
+    @PatchMapping("/status/{shootId}")
+    public GetShootResponse updateShootStatus(
+            @PathVariable Long shootId, @RequestBody UpdateShootStatusRequest request) {
+        return shootStatusService.updateShootStatus(shootId, request.status());
     }
 }

--- a/src/main/java/gigedi/dev/domain/shoot/application/ShootStatusService.java
+++ b/src/main/java/gigedi/dev/domain/shoot/application/ShootStatusService.java
@@ -1,24 +1,56 @@
 package gigedi.dev.domain.shoot.application;
 
-import jakarta.transaction.Transactional;
+import java.util.EnumSet;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.shoot.dao.ShootStatusRepository;
+import gigedi.dev.domain.shoot.domain.Shoot;
 import gigedi.dev.domain.shoot.domain.ShootStatus;
+import gigedi.dev.domain.shoot.domain.Status;
+import gigedi.dev.domain.shoot.dto.response.GetShootResponse;
 import gigedi.dev.global.error.exception.CustomException;
 import gigedi.dev.global.error.exception.ErrorCode;
+import gigedi.dev.global.util.FigmaUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ShootStatusService {
     private final ShootStatusRepository shootStatusRepository;
+    private final FigmaUtil figmaUtil;
+    private final ShootService shootService;
 
     @Transactional
-    public ShootStatus getShootStatusByShootId(Long shootId) {
-        return shootStatusRepository
-                .findByShoot_ShootId(shootId)
-                .orElseThrow(() -> new CustomException(ErrorCode.SHOOT_STATUS_NOT_FOUND));
+    public GetShootResponse updateShootStatus(Long shootId, Status newStatus) {
+        final Figma figma = figmaUtil.getCurrentFigma();
+        validateStatus(newStatus);
+        Shoot shoot = shootService.findValidShoot(shootId);
+        ShootStatus shootStatus =
+                shootStatusRepository
+                        .findByShoot_ShootIdAndFigma_FigmaId(shootId, figma.getFigmaId())
+                        .orElseGet(
+                                () -> {
+                                    ShootStatus newShootStatus =
+                                            ShootStatus.createShootStatus(newStatus, figma, shoot);
+                                    return shootStatusRepository.save(newShootStatus);
+                                });
+
+        if (shootStatus.getStatus() != newStatus) {
+            shootStatus.updateStatus(newStatus);
+        }
+        return GetShootResponse.of(
+                shoot,
+                shootService.getUsersByStatus(shoot, Status.YET),
+                shootService.getUsersByStatus(shoot, Status.DOING),
+                shootService.getUsersByStatus(shoot, Status.DONE));
+    }
+
+    private void validateStatus(Status status) {
+        if (status == null || !EnumSet.allOf(Status.class).contains(status)) {
+            throw new CustomException(ErrorCode.INVALID_STATUS);
+        }
     }
 }

--- a/src/main/java/gigedi/dev/domain/shoot/application/ShootTagService.java
+++ b/src/main/java/gigedi/dev/domain/shoot/application/ShootTagService.java
@@ -1,0 +1,30 @@
+package gigedi.dev.domain.shoot.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import gigedi.dev.domain.auth.domain.Figma;
+import gigedi.dev.domain.figma.application.FigmaService;
+import gigedi.dev.domain.shoot.dao.ShootTagRepository;
+import gigedi.dev.domain.shoot.domain.Shoot;
+import gigedi.dev.domain.shoot.domain.ShootTag;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ShootTagService {
+    private final ShootTagRepository shootTagRepository;
+    private final FigmaService figmaService;
+
+    public void createShootTags(Shoot shoot, List<String> tags) {
+        tags.forEach(
+                tag -> {
+                    Figma figma = figmaService.findByTag(tag);
+                    if (figma != null) {
+                        ShootTag shootTag = ShootTag.createShootTag(shoot, figma);
+                        shootTagRepository.save(shootTag);
+                    }
+                });
+    }
+}

--- a/src/main/java/gigedi/dev/domain/shoot/dao/ShootStatusRepository.java
+++ b/src/main/java/gigedi/dev/domain/shoot/dao/ShootStatusRepository.java
@@ -13,7 +13,5 @@ import gigedi.dev.domain.shoot.domain.Status;
 public interface ShootStatusRepository extends JpaRepository<ShootStatus, Long> {
     List<ShootStatus> findByShoot_ShootIdAndStatus(Long shootId, Status status);
 
-    Optional<ShootStatus> findByShoot_ShootId(Long shootId);
-
     Optional<ShootStatus> findByShoot_ShootIdAndFigma_FigmaId(Long shootId, Long figmaId);
 }

--- a/src/main/java/gigedi/dev/domain/shoot/dao/ShootStatusRepository.java
+++ b/src/main/java/gigedi/dev/domain/shoot/dao/ShootStatusRepository.java
@@ -14,4 +14,6 @@ public interface ShootStatusRepository extends JpaRepository<ShootStatus, Long> 
     List<ShootStatus> findByShoot_ShootIdAndStatus(Long shootId, Status status);
 
     Optional<ShootStatus> findByShoot_ShootId(Long shootId);
+
+    Optional<ShootStatus> findByShoot_ShootIdAndFigma_FigmaId(Long shootId, Long figmaId);
 }

--- a/src/main/java/gigedi/dev/domain/shoot/dao/ShootTagRepository.java
+++ b/src/main/java/gigedi/dev/domain/shoot/dao/ShootTagRepository.java
@@ -1,0 +1,13 @@
+package gigedi.dev.domain.shoot.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import gigedi.dev.domain.shoot.domain.ShootTag;
+
+@Repository
+public interface ShootTagRepository extends JpaRepository<ShootTag, Long> {
+    Optional<ShootTag> findByShoot_ShootIdAndFigma_FigmaId(Long shootId, Long figmaId);
+}

--- a/src/main/java/gigedi/dev/domain/shoot/dao/ShootTagRepository.java
+++ b/src/main/java/gigedi/dev/domain/shoot/dao/ShootTagRepository.java
@@ -1,13 +1,9 @@
 package gigedi.dev.domain.shoot.dao;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import gigedi.dev.domain.shoot.domain.ShootTag;
 
 @Repository
-public interface ShootTagRepository extends JpaRepository<ShootTag, Long> {
-    Optional<ShootTag> findByShoot_ShootIdAndFigma_FigmaId(Long shootId, Long figmaId);
-}
+public interface ShootTagRepository extends JpaRepository<ShootTag, Long> {}

--- a/src/main/java/gigedi/dev/domain/shoot/dto/request/CreateShootRequest.java
+++ b/src/main/java/gigedi/dev/domain/shoot/dto/request/CreateShootRequest.java
@@ -1,0 +1,3 @@
+package gigedi.dev.domain.shoot.dto.request;
+
+public record CreateShootRequest(String content) {}

--- a/src/main/java/gigedi/dev/global/util/ShootUtil.java
+++ b/src/main/java/gigedi/dev/global/util/ShootUtil.java
@@ -6,12 +6,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ShootUtil {
+    private static final String SPACE_DELIMITER = "\\s+";
+    private static final String TAG_PREFIX = "@";
+
     public static List<String> extractTags(String content) {
+
         if (content == null || content.isEmpty()) {
             return Collections.emptyList();
         }
-        return Arrays.stream(content.split(" "))
-                .filter(word -> word.startsWith("@"))
+        return Arrays.stream(content.split(SPACE_DELIMITER))
+                .filter(word -> word.startsWith(TAG_PREFIX))
                 .map(word -> word.substring(1))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/gigedi/dev/global/util/ShootUtil.java
+++ b/src/main/java/gigedi/dev/global/util/ShootUtil.java
@@ -1,0 +1,18 @@
+package gigedi.dev.global.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ShootUtil {
+    public static List<String> extractTags(String content) {
+        if (content == null || content.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(content.split(" "))
+                .filter(word -> word.startsWith("@"))
+                .map(word -> word.substring(1))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #60 

## 💡 작업내용
### 1. ShootService에서 ShootStatus 관련 메서드 ShootStatusService로 분리하였습니다.
- Our Shoot 조회는 쿼리 파라미터로 4개의 탭을 다 구현할 예정이어서 ShootStatusController를 만들게 되면 2개의 API만 나오게 될 것 같아 컨트롤러는 ShootController 한 개로 유지하였습니다.

### 2. 슛 상태를 업데이트 하는 로직을 수정했습니다.
- figmaUtil을 불러오지 않았어서 수정하였습니다.
- 해당 슛 정보(GetShootResponse)를 바로 반환하게 수정하였습니다.

### 3. 새로운 Shoot 생성 API 구현
- 현재 프론트엔드 작업량이 많은 것 같아 백엔드에서 유저 언급(@SUJIN) 처리를 하는 게 좋을 것 같습니다. 
- shoot content를 넘겨줄 때도 그대로 string 하나로 주고, 프론트에서 @처리를 따로 해 색상을 변경하면 될 것 같습니다.
- 슛 내용에 태그가 아닌 @ 그 자체가 들어갈 수 있는 경우는 일단 배제하는 게 좋을 것 같아요..!
- 새로운 Shoot을 생성하면 그대로 content에 담아서 요청됩니다.
- ShootUtil의 extractTags를 통해 `@`가 붙은 단어를 분리하는 로직을 작성하였습니다.
- createShootTags를 통해 해당 슛의 태그된 figma user가 저장됩니다.
ex) `@SUJIN님~! 완료하셨나요? @지선`
이렇게 content가 오면, @ 붙은 걸 분리해서 SUJIN, 지선을 추출한 뒤 해당 피그마 이름이 있는지 확인하고 저장하게 하였습니다.

## 📸 스크린샷(선택)

## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
