### PR TITLE
[Feat] 슛 생성 시 멘션이 존재하면 dm이 전송되도록 추가

### DIFF
--- a/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
+++ b/src/main/java/gigedi/dev/domain/auth/dao/FigmaRepository.java
@@ -4,9 +4,12 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import gigedi.dev.domain.auth.domain.Figma;
+import gigedi.dev.domain.file.domain.File;
 import gigedi.dev.domain.member.domain.Member;
 
 @Repository
@@ -19,5 +22,8 @@ public interface FigmaRepository extends JpaRepository<Figma, Long> {
 
     Optional<Figma> findByFigmaUserIdAndDeletedAtIsNull(String figmaUserId);
 
-    Optional<Figma> findByFigmaName(String name);
+    @Query(
+            "SELECT f FROM Figma f WHERE f.figmaName = :figmaName AND f.figmaId IN (SELECT a.figma.figmaId FROM Authority a WHERE a.file = :file)")
+    Optional<Figma> findByFigmaNameAndFile(
+            @Param("figmaName") String figmaName, @Param("file") File file);
 }

--- a/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
@@ -7,14 +7,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import gigedi.dev.domain.auth.domain.Figma;
+import gigedi.dev.domain.block.domain.Block;
 import gigedi.dev.domain.discord.domain.Discord;
 import gigedi.dev.domain.discord.dto.response.AlarmFileResponse;
 import gigedi.dev.domain.discord.dto.response.GetAlarmFileListResponse;
 import gigedi.dev.domain.figma.application.FigmaService;
 import gigedi.dev.domain.file.application.AuthorityService;
 import gigedi.dev.domain.file.domain.Authority;
+import gigedi.dev.domain.file.domain.File;
 import gigedi.dev.domain.member.domain.Member;
 import gigedi.dev.global.util.MemberUtil;
+import gigedi.dev.global.util.ShootUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -23,6 +26,7 @@ public class AlarmService {
     private final DiscordService discordService;
     private final AuthorityService authorityService;
     private final FigmaService figmaService;
+    private final DiscordDmApiService discordDmApiService;
     private final MemberUtil memberUtil;
 
     public GetAlarmFileListResponse getAlarmFileList() {
@@ -53,5 +57,30 @@ public class AlarmService {
         Member currentMember = memberUtil.getCurrentMember();
         List<Figma> figmaList = figmaService.getFigmaListByMember(currentMember);
         return authorityService.getAuthorityByFileIdAndFigmaList(fileId, figmaList);
+    }
+
+    public void sendAlarmToDiscord(
+            List<String> tags, Block block, Figma senderFigma, String message) {
+        String sender = senderFigma.getFigmaName();
+        String blockTitle = block.getTitle();
+        String archiveTitle = block.getArchive().getTitle();
+        File currentFile = block.getArchive().getFile();
+        List<Figma> receiverList =
+                authorityService.getAlarmTargetListByFigmaName(currentFile, tags);
+        String content = ShootUtil.highlightMentions(message);
+
+        receiverList.forEach(
+                receiver -> {
+                    String channelId = discordService.getDmChannelByMember(receiver.getMember());
+                    if (channelId != null) {
+                        discordDmApiService.sendDMMessage(
+                                channelId,
+                                sender,
+                                receiver.getFigmaName(),
+                                ShootUtil.highlightText(archiveTitle),
+                                ShootUtil.highlightText(blockTitle),
+                                content);
+                    }
+                });
     }
 }

--- a/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/AlarmService.java
@@ -67,7 +67,6 @@ public class AlarmService {
         File currentFile = block.getArchive().getFile();
         List<Figma> receiverList =
                 authorityService.getAlarmTargetListByFigmaName(currentFile, tags);
-        String content = ShootUtil.highlightMentions(message);
 
         receiverList.forEach(
                 receiver -> {
@@ -79,7 +78,7 @@ public class AlarmService {
                                 receiver.getFigmaName(),
                                 ShootUtil.highlightText(archiveTitle),
                                 ShootUtil.highlightText(blockTitle),
-                                content);
+                                ShootUtil.highlightMentions(message));
                     }
                 });
     }

--- a/src/main/java/gigedi/dev/domain/discord/application/DiscordService.java
+++ b/src/main/java/gigedi/dev/domain/discord/application/DiscordService.java
@@ -42,4 +42,9 @@ public class DiscordService {
             throw new CustomException(ErrorCode.DISCORD_ACCOUNT_ALREADY_EXISTS);
         }
     }
+
+    @Transactional(readOnly = true)
+    public String getDmChannelByMember(Member member) {
+        return discordRepository.findByMember(member).map(Discord::getDmChannel).orElse(null);
+    }
 }

--- a/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
+++ b/src/main/java/gigedi/dev/domain/figma/application/FigmaService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import gigedi.dev.domain.auth.dao.FigmaRepository;
 import gigedi.dev.domain.auth.domain.Figma;
+import gigedi.dev.domain.file.domain.File;
 import gigedi.dev.domain.member.domain.Member;
 import gigedi.dev.global.error.exception.CustomException;
 import gigedi.dev.global.error.exception.ErrorCode;
@@ -31,9 +32,9 @@ public class FigmaService {
                 .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_NOT_CONNECTED));
     }
 
-    public Figma findByTag(String tag) {
+    public Figma findByTag(String tag, File file) {
         return figmaRepository
-                .findByFigmaName(tag)
+                .findByFigmaNameAndFile(tag, file)
                 .orElseThrow(() -> new CustomException(ErrorCode.FIGMA_USER_INFO_NOT_FOUND));
     }
 

--- a/src/main/java/gigedi/dev/domain/file/application/AuthorityService.java
+++ b/src/main/java/gigedi/dev/domain/file/application/AuthorityService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.file.dao.AuthorityRepository;
 import gigedi.dev.domain.file.domain.Authority;
+import gigedi.dev.domain.file.domain.File;
 import gigedi.dev.global.error.exception.CustomException;
 import gigedi.dev.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -27,5 +28,10 @@ public class AuthorityService {
         return authorityRepository
                 .findByFileAndActiveFigma(fileId, figmaList)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTHORITY_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Figma> getAlarmTargetListByFigmaName(File file, List<String> figmaNameList) {
+        return authorityRepository.getFigmaNamesWithActiveAlarmByFile(file, figmaNameList);
     }
 }

--- a/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryCustom.java
+++ b/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryCustom.java
@@ -5,9 +5,12 @@ import java.util.Optional;
 
 import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.file.domain.Authority;
+import gigedi.dev.domain.file.domain.File;
 
 public interface AuthorityRepositoryCustom {
     List<Authority> findRelatedAuthorities(Long memberId);
 
     Optional<Authority> findByFileAndActiveFigma(Long fileId, List<Figma> figmaList);
+
+    List<Figma> getFigmaNamesWithActiveAlarmByFile(File file, List<String> figmaNames);
 }

--- a/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryImpl.java
+++ b/src/main/java/gigedi/dev/domain/file/dao/AuthorityRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.file.domain.Authority;
+import gigedi.dev.domain.file.domain.File;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -44,5 +45,19 @@ public class AuthorityRepositoryImpl implements AuthorityRepositoryCustom {
                                         .and(authority.figma.in(figmaList))
                                         .and(authority.figma.deletedAt.isNull()))
                         .fetchOne());
+    }
+
+    @Override
+    public List<Figma> getFigmaNamesWithActiveAlarmByFile(File file, List<String> figmaNames) {
+        return queryFactory
+                .selectFrom(figma)
+                .join(authority)
+                .on(authority.figma.eq(figma))
+                .where(
+                        authority.file.eq(file),
+                        figma.figmaName.in(figmaNames),
+                        authority.alarm.isTrue(),
+                        figma.deletedAt.isNull())
+                .fetch();
     }
 }

--- a/src/main/java/gigedi/dev/domain/shoot/application/ShootService.java
+++ b/src/main/java/gigedi/dev/domain/shoot/application/ShootService.java
@@ -10,6 +10,7 @@ import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.block.application.BlockService;
 import gigedi.dev.domain.block.domain.Block;
 import gigedi.dev.domain.discord.application.AlarmService;
+import gigedi.dev.domain.file.domain.File;
 import gigedi.dev.domain.shoot.dao.ShootRepository;
 import gigedi.dev.domain.shoot.dao.ShootStatusRepository;
 import gigedi.dev.domain.shoot.domain.Shoot;
@@ -67,8 +68,9 @@ public class ShootService {
     }
 
     private List<String> processTags(String content, Shoot shoot) {
+        File currentFile = figmaUtil.getCurrentFile();
         List<String> tags = ShootUtil.extractTags(content);
-        shootTagService.createShootTags(shoot, tags);
+        shootTagService.createShootTags(shoot, tags, currentFile);
         return tags;
     }
 

--- a/src/main/java/gigedi/dev/domain/shoot/application/ShootTagService.java
+++ b/src/main/java/gigedi/dev/domain/shoot/application/ShootTagService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import gigedi.dev.domain.auth.domain.Figma;
 import gigedi.dev.domain.figma.application.FigmaService;
+import gigedi.dev.domain.file.domain.File;
 import gigedi.dev.domain.shoot.dao.ShootTagRepository;
 import gigedi.dev.domain.shoot.domain.Shoot;
 import gigedi.dev.domain.shoot.domain.ShootTag;
@@ -17,10 +18,10 @@ public class ShootTagService {
     private final ShootTagRepository shootTagRepository;
     private final FigmaService figmaService;
 
-    public void createShootTags(Shoot shoot, List<String> tags) {
+    public void createShootTags(Shoot shoot, List<String> tags, File currentFile) {
         tags.forEach(
                 tag -> {
-                    Figma figma = figmaService.findByTag(tag);
+                    Figma figma = figmaService.findByTag(tag, currentFile);
                     if (figma != null) {
                         ShootTag shootTag = ShootTag.createShootTag(shoot, figma);
                         shootTagRepository.save(shootTag);

--- a/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
+++ b/src/main/java/gigedi/dev/global/common/constants/SecurityConstants.java
@@ -17,6 +17,7 @@ public final class SecurityConstants {
     public static final String GOOGLE_WITHDRAWAL_URL =
             "https://accounts.google.com/o/oauth2/revoke?token=";
 
+    public static final String DISCORD_HOST = "discord.com";
     public static final String DISCORD_TOKEN_URL = "https://discord.com/api/oauth2/token";
     public static final String DISCORD_USER_INFO_URL = "https://discord.com/api/users/@me";
     public static final String DISCORD_CREATE_DM_CHANNEL_URL =
@@ -24,6 +25,7 @@ public final class SecurityConstants {
     public static final String DISCORD_GUILD_URL = "https://discord.com/api/v10/guilds";
     public static final String DISCORD_DISCONNECT_URL =
             "https://discord.com/api/oauth2/token/revoke";
+    public static final String DISCORD_SEND_DM_URL = "/api/channels/{channelId}/messages";
 
     public static final String FIGMA_HOST = "api.figma.com";
     public static final String FIGMA_GET_ID_TOKEN_URL = "https://www.figma.com/api/oauth/token";

--- a/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
+++ b/src/main/java/gigedi/dev/global/error/exception/ErrorCode.java
@@ -72,6 +72,7 @@ public enum ErrorCode {
     DISCORD_TOKEN_REISSUE_FAILED(HttpStatus.BAD_REQUEST, "디스코드 토큰 재발급 과정에서 오류가 발생했습니다."),
     DISCORD_DISCONNECT_FAILED(HttpStatus.BAD_REQUEST, "디스코드 연결 해제 과정에서 오류가 발생했습니다."),
     DISCORD_ACCOUNT_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "연결된 디스코드 계정이 이미 존재합니다."),
+    DISCORD_DM_MESSAGE_SEND_FAILED(HttpStatus.BAD_REQUEST, "디스코드 DM 전송에 실패했습니다."),
 
     // Authority
     AUTHORITY_NOT_FOUND(HttpStatus.NOT_FOUND, "피그마 계정과 파일의 연관 정보가 존재하지 않습니다."),

--- a/src/main/java/gigedi/dev/global/util/ShootUtil.java
+++ b/src/main/java/gigedi/dev/global/util/ShootUtil.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 public class ShootUtil {
     private static final String SPACE_DELIMITER = "\\s+";
     private static final String TAG_PREFIX = "@";
+    private static final String HIGHLIGHT_FORMAT = "**%s**";
 
     public static List<String> extractTags(String content) {
 
@@ -18,5 +19,26 @@ public class ShootUtil {
                 .filter(word -> word.startsWith(TAG_PREFIX))
                 .map(word -> word.substring(1))
                 .collect(Collectors.toList());
+    }
+
+    public static String highlightMentions(String content) {
+        if (content == null || content.isEmpty()) {
+            return content;
+        }
+
+        return Arrays.stream(content.split(SPACE_DELIMITER))
+                .map(
+                        word ->
+                                word.startsWith(TAG_PREFIX)
+                                        ? String.format(HIGHLIGHT_FORMAT, word)
+                                        : word)
+                .collect(Collectors.joining(" "));
+    }
+
+    public static String highlightText(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        return String.format(HIGHLIGHT_FORMAT, text);
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #66 

## 💡 작업내용
### 슛 생성 시 멘션이 존재하면 dm이 전송되도록 추가
- 슛 생성 시 태그를 생성하는 `processTags()`에서 반환값을 추가하여 dm 전송에 이용되도록 구현하였습니다.
- `ShootUtil`을 이용하여 dm에 전송될 문자열들을 가공하였습니다. 

### 태그 생성 시 피그마 탐색 로직 수정
- 이전 로직에서는 피그마 전체 테이블에서 태그와 매칭되는 피그마 객체를 찾았는데, 해당 로직으로 실행할 경우 같은 이름이 피그마 테이블에 있으면 `NPE`가 발생하였습니다.
- 이에 슛 생성 요청을 보낸 파일 내에 있는 피그마 객체 중 태그와 매칭되는 피그마 객체가 반환되도록 수정하였습니다. 

## 📸 스크린샷(선택)

<img src="https://github.com/user-attachments/assets/d3fcf865-3f3c-493c-823b-fd454251ab7e" width="45%">
<img src="https://github.com/user-attachments/assets/bbb97799-1521-43fe-9c5f-744c2ac1c877" width="45%">


## 📝 기타
- 파일 내에 멘션 수가 많아지는 경우 슛 생성이 느려져 이 부분의 최적화를 고민해야할 것 같습니다.
- 현재 태그 생성 시 피그마 탐색 로직과 dm전송을 위해 수신자 Figma 객체 리스트를 받아오는 과정에서 중복 로직이 발생하여 리팩토링을 해야할 것 같습니다.
- 현재는 파일 내에 중복되는 피그마 이름이 없다고 가정하였기에 중복되는 이름이 존재한다면 똑같이 `NPE`가 발생할 것 같아 이 부분에 대하여 고민해봐야 할 것 같습니다.
- 현재는 테스트 편의 상 내 자신을 멘션해도 dm이 오도록 설정했지만 이후 이 부분에 대하여 기획과 회의가 필요할 것 같습니다. 
