### PR TITLE
[Fix] 리프레시 토큰 저장을 redis로 수정

### DIFF
--- a/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/JwtTokenService.java
@@ -31,7 +31,8 @@ public class JwtTokenService {
 
     public String createRefreshToken(Long memberId) {
         String token = jwtUtil.generateRefreshToken(memberId);
-        RefreshToken refreshToken = RefreshToken.of(memberId, token);
+        RefreshToken refreshToken =
+                RefreshToken.of(memberId, token, jwtUtil.getRefreshTokenExpirationTime());
         refreshTokenRepository.save(refreshToken);
         return token;
     }
@@ -71,7 +72,7 @@ public class JwtTokenService {
                         .orElseThrow(() -> new CustomException(ErrorCode.MISSING_JWT_TOKEN));
         RefreshTokenDto refreshTokenDto =
                 jwtUtil.generateRefreshTokenDto(refreshToken.getMemberId());
-        refreshToken.updateRefreshToken(refreshTokenDto.getToken());
+        refreshToken.updateRefreshToken(refreshTokenDto.getToken(), refreshTokenDto.getTtl());
         refreshTokenRepository.save(refreshToken);
         return refreshTokenDto;
     }

--- a/src/main/java/gigedi/dev/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/gigedi/dev/domain/auth/dao/RefreshTokenRepository.java
@@ -1,7 +1,7 @@
 package gigedi.dev.domain.auth.dao;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 
 import gigedi.dev.domain.auth.domain.RefreshToken;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {}
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {}

--- a/src/main/java/gigedi/dev/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/gigedi/dev/domain/auth/domain/RefreshToken.java
@@ -1,6 +1,8 @@
 package gigedi.dev.domain.auth.domain;
 
-import jakarta.persistence.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,23 +10,27 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
+@RedisHash(value = "refreshToken")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
     @Id private Long memberId;
     private String token;
 
+    @TimeToLive private long ttl;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private RefreshToken(Long memberId, String token) {
+    private RefreshToken(Long memberId, String token, long ttl) {
         this.memberId = memberId;
         this.token = token;
+        this.ttl = ttl;
     }
 
-    public static RefreshToken of(Long memberId, String token) {
-        return RefreshToken.builder().memberId(memberId).token(token).build();
+    public static RefreshToken of(Long memberId, String token, long ttl) {
+        return RefreshToken.builder().memberId(memberId).token(token).ttl(ttl).build();
     }
 
-    public void updateRefreshToken(String newToken) {
+    public void updateRefreshToken(String newToken, long newTtl) {
         this.token = newToken;
+        this.ttl = newTtl;
     }
 }

--- a/src/main/java/gigedi/dev/domain/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/RefreshTokenDto.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class RefreshTokenDto {
     private Long memberId;
     private String token;
+    private Long ttl;
 }

--- a/src/main/java/gigedi/dev/global/util/JwtUtil.java
+++ b/src/main/java/gigedi/dev/global/util/JwtUtil.java
@@ -88,7 +88,10 @@ public class JwtUtil {
         try {
             Jws<Claims> claims = getClaims(token, getRefreshTokenKey());
 
-            return new RefreshTokenDto(Long.parseLong(claims.getBody().getSubject()), token);
+            return new RefreshTokenDto(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    token,
+                    jwtProperties.getRefreshTokenExpirationTime());
         } catch (ExpiredJwtException e) {
             throw e;
         } catch (Exception e) {
@@ -109,7 +112,8 @@ public class JwtUtil {
         Date expiredAt =
                 new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
         String tokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
-        return new RefreshTokenDto(memberId, tokenValue);
+        return new RefreshTokenDto(
+                memberId, tokenValue, jwtProperties.getRefreshTokenExpirationTime());
     }
 
     private Jws<Claims> getClaims(String token, Key key) {
@@ -118,5 +122,9 @@ public class JwtUtil {
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token);
+    }
+
+    public long getRefreshTokenExpirationTime() {
+        return jwtProperties.getRefreshTokenExpirationTime();
     }
 }

--- a/src/test/java/gigedi/dev/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/gigedi/dev/domain/auth/application/AuthServiceTest.java
@@ -84,8 +84,11 @@ class AuthServiceTest {
             // given
             TokenRefreshRequest request = new TokenRefreshRequest();
             request.setRefreshToken("oldRefreshToken");
-            RefreshTokenDto oldRefreshTokenDto = new RefreshTokenDto(1L, "oldRefreshToken");
-            RefreshTokenDto newRefreshTokenDto = new RefreshTokenDto(1L, "newRefreshToken");
+            Long testTtl = 100L;
+            RefreshTokenDto oldRefreshTokenDto =
+                    new RefreshTokenDto(1L, "oldRefreshToken", testTtl);
+            RefreshTokenDto newRefreshTokenDto =
+                    new RefreshTokenDto(1L, "newRefreshToken", testTtl);
             AccessTokenDto accessTokenDto =
                     new AccessTokenDto(1L, MemberRole.USER, "newAccessToken");
             Member member = mock(Member.class);


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #73 

## 💡 작업내용
### 리프레시 토큰 redis로 저장
- `@Entity`와 `JpaRepository` 대신 `@RedisHash`와 `CrudRepository`를 통해 redis에 저장되도록 설정했습니다.
- `@TimeToLive`로 `ttl`을 설정하여 시간 만료 시 자동으로 삭제되도록 설정하였습니다.

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/17867bac-6555-4e6d-bcef-a2b835bd9dcc)
![image](https://github.com/user-attachments/assets/b5b365f6-817e-4c19-9e3b-eba484fb78d0)

## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
