### PR TITLE
[Bug] 피그마 연결 계정 조회 시 반환 id값 수정

### DIFF
--- a/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
+++ b/src/main/java/gigedi/dev/domain/auth/application/AuthService.java
@@ -73,7 +73,7 @@ public class AuthService {
         final Member currentMember = memberUtil.getCurrentMember();
         List<Figma> figmaList = figmaRepository.findByMemberAndDeletedAtIsNull(currentMember);
         return figmaList.stream()
-                .map(figma -> new FigmaAccountResponse(figma.getFigmaUserId(), figma.getEmail()))
+                .map(figma -> new FigmaAccountResponse(figma.getFigmaId(), figma.getEmail()))
                 .toList();
     }
 

--- a/src/main/java/gigedi/dev/domain/auth/dto/response/FigmaAccountResponse.java
+++ b/src/main/java/gigedi/dev/domain/auth/dto/response/FigmaAccountResponse.java
@@ -3,4 +3,4 @@ package gigedi.dev.domain.auth.dto.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record FigmaAccountResponse(String figmaId, String email) {}
+public record FigmaAccountResponse(Long figmaId, String email) {}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- hotfix

## 💡 작업내용
### 피그마 연결 계정 조회 시 반환 id값 수정
- 현재 삭제 시 로직이 피그마 유저 id가 아닌 피그마 id값을 기준으로 하고 있어 피그마 계정 정보를 조회하는 로직에서 피그마 id값이 반환되도록 수정하였습니다. 

## 📸 스크린샷(선택)

## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
